### PR TITLE
use `rake spec`; `rake test` doesn't exist.

### DIFF
--- a/content/introduction/getting-started.md
+++ b/content/introduction/getting-started.md
@@ -175,7 +175,7 @@ If you have trouble, your <tt>DATABASE_URL</tt> is defined in <tt>.env.test</tt>
 Now we have a test, we can see it fail:
 
 ```shell
-$ bundle exec rake test
+$ bundle exec rake spec
 F.
 
 Failures:


### PR DESCRIPTION
I was following the getting started guide, and encountered this:

```sh
ttilberg@timdesktop:~/dev/hanami_hotdogs$ bundle exec rake test
rake aborted!
Don't know how to build task 'test' (see --tasks)
/home/ttilberg/.rbenv/versions/2.5.1/bin/bundle:23:in `load'
/home/ttilberg/.rbenv/versions/2.5.1/bin/bundle:23:in `<main>'
(See full trace by running task with --trace)
ttilberg@timdesktop:~/dev/hanami_hotdogs$ bundle exec rake --tasks
rake environment  # Load the full project
rake spec         # Run RSpec code examples
```

Hanami Version: v1.3.0
