### PR TITLE
Change RSpec to default on guides

### DIFF
--- a/content/actions/testing.md
+++ b/content/actions/testing.md
@@ -4,7 +4,7 @@ order: 140
 ---
 
 Hanami pays a lot of attention to code testability and it offers advanced features to make our lives easier.
-The framework supports Minitest (default) and RSpec.
+The framework supports RSpec (default) and Minitest.
 
 ## Unit Tests
 

--- a/content/command-line/project.md
+++ b/content/command-line/project.md
@@ -32,8 +32,8 @@ The default testing framework is Minitest.
 
 We can use the `--test` argument to specify a different framework, from the list below:
 
-  * `minitest` (default)
-  * `rspec`
+  * `rspec` (default)
+  * `minitest`
 
 ## Template Engine
 


### PR DESCRIPTION
RSpec is default since Hanami 1.3. This commit changes the places that
identified Minitest as default and replaced by RSpec