### PR TITLE
Expect not to create a book if invalid

### DIFF
--- a/content/architecture/interactors.md
+++ b/content/architecture/interactors.md
@@ -554,7 +554,7 @@ RSpec.describe Web::Controllers::Books::Create do
   context 'with invalid params' do
     let(:params) { Hash[book: {}] }
 
-    it 'calls interactor' do
+    it 'does not call interactor' do
       expect(interactor).to_not receive(:call)
       response = action.call(params)
     end

--- a/content/architecture/interactors.md
+++ b/content/architecture/interactors.md
@@ -555,7 +555,7 @@ RSpec.describe Web::Controllers::Books::Create do
     let(:params) { Hash[book: {}] }
 
     it 'calls interactor' do
-      expect(interactor).to receive(:call)
+      expect(interactor).to_not receive(:call)
       response = action.call(params)
     end
 


### PR DESCRIPTION
When `params` are invalid, we don't expect to call the `AddBook` interactor. Since the controller is performing validation - the interactor is not used.

Change spec to match this, assert that interactor does not receive call.


