### PR TITLE
Use described_class in create book controller spec

### DIFF
--- a/content/architecture/interactors.md
+++ b/content/architecture/interactors.md
@@ -554,8 +554,8 @@ RSpec.describe Web::Controllers::Books::Create do
   context 'with invalid params' do
     let(:params) { Hash[book: {}] }
 
-    it 'calls interactor' do
-      expect(interactor).to receive(:call)
+    it "doesn't call interactor" do
+      expect(interactor).to_not receive(:call)
       response = action.call(params)
     end
 

--- a/content/architecture/interactors.md
+++ b/content/architecture/interactors.md
@@ -533,7 +533,7 @@ and leverage a double for our `AddBook` interactor:
 
 RSpec.describe Web::Controllers::Books::Create do
   let(:interactor) { instance_double('AddBook', call: nil) }
-  let(:action) { Web::Controllers::Books::Create.new(interactor: interactor) }
+  let(:action) { described_class.new(interactor: interactor) }
 
   context 'with valid params' do
     let(:params) { Hash[book: { title: '1984', author: 'George Orwell' }] }

--- a/content/architecture/interactors.md
+++ b/content/architecture/interactors.md
@@ -554,8 +554,8 @@ RSpec.describe Web::Controllers::Books::Create do
   context 'with invalid params' do
     let(:params) { Hash[book: {}] }
 
-    it "doesn't call interactor" do
-      expect(interactor).to_not receive(:call)
+    it 'calls interactor' do
+      expect(interactor).to receive(:call)
       response = action.call(params)
     end
 


### PR DESCRIPTION
In the Getting Started Guide -> [Implementing Create Action ](https://github.com/hanami/guides/blame/master/content/introduction/getting-started.md#L787) section when `create_spec.rb` file is originally created, `let(:action)` is defined as  `described_class.new`. But when we proceed to Architecture -> Interactors guide, then we notice that `let(:action)` is set to the full name of the controller. This PR changes it to `described_class.new` so that it feels less confusing when you read Getting Started Guide and then Architecture -> Interactors guide and compare changes.