### PR TITLE
Fix broken 404 links to guides.hanamirb.org

### DIFF
--- a/content/mailers/delivery.md
+++ b/content/mailers/delivery.md
@@ -64,7 +64,7 @@ Hanami.configure do
   mailer do
     root Hanami.root.join("lib", "bookshelf", "mailers")
 
-    # See http://hanamirb.org/guides/1.2/mailers/delivery
+    # See https://guides.hanamirb.org/mailers/delivery
     delivery :test
   end
 

--- a/content/mailers/share-code.md
+++ b/content/mailers/share-code.md
@@ -38,7 +38,7 @@ Hanami.configure do
   mailer do
     root 'lib/bookshelf/mailers'
 
-    # See http://hanamirb.org/guides/1.2/mailers/delivery
+    # See https://guides.hanamirb.org/mailers/delivery
     delivery :test
 
     prepare do

--- a/content/projects/code-reloading.md
+++ b/content/projects/code-reloading.md
@@ -14,7 +14,7 @@ New generated projects have this entry in their `Gemfile`:
 ```ruby
 group :development do
   # Code reloading
-  # See: http://hanamirb.org/guides/1.2/projects/code-reloading
+  # See: https://guides.hanamirb.org/projects/code-reloading
   gem 'shotgun'
 end
 ```


### PR DESCRIPTION
* Add guides subdomain to broken links to fix https://github.com/hanami/hanami/issues/980
* Remove version 1.2 from urls