### PR TITLE
improve readability of flash-like block elements

### DIFF
--- a/themes/hanami/static/assets/css/theme.css
+++ b/themes/hanami/static/assets/css/theme.css
@@ -242,20 +242,20 @@ p.warning {
 
 p.notice {
   color: #FFF;
-  border-color: #35DDFF;
-  background-color: #35DDFF;
+  border-color: #27A8C2;
+  background-color: #27A8C2;
 }
 
 p.convention {
   color: #fff;
-  border-color: #46E895;
-  background-color: #46E895;
+  border-color: #329663;
+  background-color: #329663;
 }
 
 p.warning {
   color: #fff;
-  border-color: #fc7c5f;
-  background-color: #fc7c5f;
+  border-color: #b4391d;
+  background-color: #b4391d;
 }
 
 p.convention code,


### PR DESCRIPTION
i hope this does not shoot through some global design styles, however, i do think it makes the site much more legible. colors are rather randomly darkened.

alternative: darken the font color for these elements.

see #9 

current:

![screenshot from 2019-02-23 20-16-48](https://user-images.githubusercontent.com/1685114/53290113-69c40c00-37a8-11e9-9765-781e63ce018d.png)

changed:

![screenshot from 2019-02-23 20-19-16](https://user-images.githubusercontent.com/1685114/53290114-69c40c00-37a8-11e9-9250-2ac6a5ae5795.png)

