### PR TITLE
Add information about :logger mailer mode

### DIFF
--- a/content/mailers/delivery.md
+++ b/content/mailers/delivery.md
@@ -49,6 +49,7 @@ It accepts a symbol that is translated into a delivery strategy:
   * Sendmail (`:sendmail`)
   * SMTP (`:smtp`, for local SMTP installations)
   * SMTP Connection (`:smtp_connection`, via `Net::SMTP` - for remote SMTP installations)
+  * Logger (`:logger`, prints email details to the console - useful in development)
   * Test (`:test`, for testing purposes)
 
 It defaults to SMTP (`:smtp`) for production environment, while `:test` is automatically set for development and test.


### PR DESCRIPTION
Adds information about `:logger` mode for mailer. This is very useful for development and I was quite upset it's not available. Then I wrote my own mode and then I discovered it was already available, but undocumented.

By the way, I think this should be default mode in development environment, so I'm thinking about adding it as default in `unstable` branch of `hanami/hanami` - WDYT?