### PR TITLE
Fix broken link in rake.md

### DIFF
--- a/content/projects/rake.md
+++ b/content/projects/rake.md
@@ -60,7 +60,7 @@ For instance, Heroku expects to find the following Rake tasks in a Ruby applicat
 
 For Heroku, there isn't a way to customize the deploy, so we're supporting these "standard" Rake tasks from Ruby on Rails.
 
-**If you are in control of your deployment, don't rely on these Rake tasks, but please use `hanami` [command line](/guides/command-line/database), instead.**
+**If you are in control of your deployment, don't rely on these Rake tasks, but please use `hanami` [command line](/command-line/database), instead.**
 
 ## Custom rake tasks
 

--- a/content/projects/rake.md
+++ b/content/projects/rake.md
@@ -60,7 +60,7 @@ For instance, Heroku expects to find the following Rake tasks in a Ruby applicat
 
 For Heroku, there isn't a way to customize the deploy, so we're supporting these "standard" Rake tasks from Ruby on Rails.
 
-**If you are in control of your deployment, don't rely on these Rake tasks, but please use `hanami` [command line](/guides/1.2/command-line/database), instead.**
+**If you are in control of your deployment, don't rely on these Rake tasks, but please use `hanami` [command line](/guides/command-line/database), instead.**
 
 ## Custom rake tasks
 


### PR DESCRIPTION
The original link was pointing to a page that no-longer exists