### PR TITLE
Fix link to dedicated article on PostgreSQL types

### DIFF
--- a/content/migrations/create-table.md
+++ b/content/migrations/create-table.md
@@ -50,7 +50,7 @@ It supports the following options:
 
 <p class="convention">
   Note that Hanami natively supports <strong>PostgreSQL data types</strong>.
-  Learn more about them in the <a href="/models/postgresql/">dedicated article</a>.
+  Learn more about them in the <a href="/repositories/postgresql/">dedicated article</a>.
 </p>
 
 ## Primary Key


### PR DESCRIPTION
The previous link was pointing towards `models/postgresql/` which doesn't exist.