### PR TITLE
Update link to point at ROM 5.0 docs

### DIFF
--- a/content/repositories/overview.md
+++ b/content/repositories/overview.md
@@ -118,7 +118,7 @@ This is a **huge improvement**, because:
   </p>
   <p>
     Learn more on how to craft queries with
-    <a href="http://rom-rb.org/current/learn/sql/queries/">ROM</a>
+    <a href="https://rom-rb.org/5.0/learn/sql/queries/index.html">ROM</a>
     and <a href="http://sequel.jeremyevans.net/documentation.html">Sequel</a>.
   </p>
 </div>


### PR DESCRIPTION
I updated this to close #44, which has been left open for a few months.