### PR TITLE
Remove #find_book from HasMany documentation

### DIFF
--- a/content/associations/has-many.md
+++ b/content/associations/has-many.md
@@ -174,10 +174,6 @@ class AuthorRepository < Hanami::Repository
     assoc(:books, author).where(on_sale: true).count
   end
 
-  def find_book(author, id)
-    book_for(author, id).one
-  end
-
   def book_exists?(author, id)
     book_for(author, id).exists?
   end


### PR DESCRIPTION
Per Hanami/Model's issue #550, HasMany does not implement #one.

**Note:** This change is strongly related to https://github.com/hanami/model/pull/554. They should either be closed or merged together.