### PR TITLE
Fix code sample for extending existing CLI commands

### DIFF
--- a/content/command-line/plugins.md
+++ b/content/command-line/plugins.md
@@ -60,8 +60,8 @@ module Hanami
   end
 end
 
-Hanami::CLI.before("db migrate"), ->(*) { puts "I am about to migrate database.." }
-Hanami::CLI.after "db migrate", Hanami::Database::Analyzer::Stats.new
+Hanami::CLI::Commands.before("db migrate"), ->(*) { puts "I am about to migrate database.." }
+Hanami::CLI::Commands.after "db migrate", Hanami::Database::Analyzer::Stats.new
 ```
 
 By running `db migrate`, the third-party code is executed:


### PR DESCRIPTION
Not sure if it's something new (because of renaming `hanami-cli` to `dry-cli`?) - as I think it worked before. But now for freshly generated Hanami project (version 1.3.3) I needed to extend via `Hanami::CLI::Commands`.