### PR TITLE
Update theme.css

### DIFF
--- a/themes/hanami/static/assets/css/theme.css
+++ b/themes/hanami/static/assets/css/theme.css
@@ -13,7 +13,7 @@ body {
 
 a:link,
 a:visited {
-  color: #35DDFF;
+  color: #00aacc;
 }
 
 a:hover,


### PR DESCRIPTION
I'm suggesting a less bright colour for the links across the documentation.
The suggested colour seems a bit more on the green side - I don't know what would be the appropriate name.

I have found the cyan colour very difficult to read, I'm not sure if others find the same.

### before
![image](https://user-images.githubusercontent.com/136777/75979800-30ed6580-5ed9-11ea-955f-22c375d8f27a.png)

### after

![image](https://user-images.githubusercontent.com/136777/75979781-2763fd80-5ed9-11ea-840e-b871ad9063c5.png)
