### PR TITLE
Update alter-table.md

### DIFF
--- a/content/migrations/alter-table.md
+++ b/content/migrations/alter-table.md
@@ -28,7 +28,7 @@ Hanami::Model.migration do
     alter_table :users do
       # `users` table is implicit within this block, so it can be omitted.
       add_column :email, String,  null: false, unique: true
-      set_column_default :visits_counts, default: 0
+      set_column_default :visits_counts, 0
     end
   end
 end


### PR DESCRIPTION
I was copying and pasting code from an example with `set_column_default` and noticed that default value is provided in an incorrect format. This method accepts the default value directly as a second argument instead of a hash with `default` key.