### PR TITLE
Add entity definition to entity custom schema guide.

### DIFF
--- a/content/entities/custom-schema.md
+++ b/content/entities/custom-schema.md
@@ -25,6 +25,7 @@ class User < Hanami::Entity
     attribute :name,       Types::String
     attribute :email,      Types::String.constrained(format: EMAIL_FORMAT)
     attribute :age,        Types::Int.constrained(gt: 18)
+    attribute :profile,    Types::Entity(Profile)
     attribute :codes,      Types::Collection(Types::Coercible::Int)
     attribute :comments,   Types::Collection(Comment)
     attribute :created_at, Types::Time


### PR DESCRIPTION
The title says all.
I want to define entity attributes. It doesn't appear to be in the documentation.

So I added it.