### PR TITLE
A typo in the documentation

### DIFF
--- a/content/introduction/getting-started.md
+++ b/content/introduction/getting-started.md
@@ -175,7 +175,7 @@ If you have trouble, your <tt>DATABASE_URL</tt> is defined in <tt>.env.test</tt>
 Now we have a test; we can see it fail:
 
 ```shell
-$ bundle exec rake
+$ bundle exec rspec
 F.
 
 Failures:


### PR DESCRIPTION
`bundle exec rake` should become `bundle exec rspec` if I'm not mistaken.