### PR TITLE
Update Gemfile snippet in preprocessors.md

### DIFF
--- a/content/assets/preprocessors.md
+++ b/content/assets/preprocessors.md
@@ -76,7 +76,7 @@ In order to use one or more of them, be sure to include the corresponding gem in
 ```ruby
 # Gemfile
 # ...
-gem 'sass'
+gem 'sassc'
 ```
 
 <p class="notice">


### PR DESCRIPTION
Hey, I've tried building a simple app with SCSS assets compilation, but when I added the `sass` gem as suggested in the docs it was crashing with following error:
![image](https://user-images.githubusercontent.com/5732023/88365245-b472fa80-cd85-11ea-820e-8544639da57e.png)

it seems that the `sass` gem is deprecated and the authors suggest using `sassc`. After this change the assets started compiling normally.