### PR TITLE
Fix Ruby syntax of plugin hook example

### DIFF
--- a/content/command-line/plugins.md
+++ b/content/command-line/plugins.md
@@ -60,7 +60,7 @@ module Hanami
   end
 end
 
-Hanami::CLI::Commands.before("db migrate"), ->(*) { puts "I am about to migrate database.." }
+Hanami::CLI::Commands.before("db migrate") { puts "I am about to migrate database.." }
 Hanami::CLI::Commands.after "db migrate", Hanami::Database::Analyzer::Stats.new
 ```
 


### PR DESCRIPTION
Fixed the invalid syntax and opted to just use a block vs a stabby lambda.