### PR TITLE
Update has_many guide to fix error

### DIFF
--- a/content/associations/has-many.md
+++ b/content/associations/has-many.md
@@ -50,6 +50,7 @@ Hanami::Model.migration do
       foreign_key :author_id, :authors, on_delete: :cascade
 
       column :title,      String,   null: false
+      column :on_sale,    TrueClass, null: false, default: false
       column :created_at, DateTime, null: false
       column :updated_at, DateTime, null: false
     end

--- a/content/associations/has-many.md
+++ b/content/associations/has-many.md
@@ -47,7 +47,7 @@ Hanami::Model.migration do
     create_table :books do
       primary_key :id
 
-      foreign_key :author_id, :authors, on_delete: :cascade, null: false
+      foreign_key :author_id, :authors, on_delete: :cascade
 
       column :title,      String,   null: false
       column :created_at, DateTime, null: false


### PR DESCRIPTION
The `has_many` guide specifies a `NOT NULL` constraint on the `author_id` foreign key, but this breaks the guide. I believe it's a mistake, judging by the migration used in the `hanami/model` [specs](https://github.com/hanami/model/blob/1fb18741c3c36a2db8d4269a385b99b7e9b16cf3/spec/support/fixtures/database_migrations/20160830094941_create_books.rb#L8).

At the bottom of the guide, `on_sale` is referenced as a column but wasn't created during the migration, which causes the examples to fail. The migration above has the `on_sale` column as an example, so it was copied over.