### PR TITLE
Use 'now' for year, rather than hard-coded

### DIFF
--- a/themes/hanami/layouts/index.html
+++ b/themes/hanami/layouts/index.html
@@ -294,8 +294,8 @@
         <div class="row align-items-center justify-content-md-between">
           <div class="col-md-6">
             <div class="copyright">
-            Hanami is a web framework for Ruby — 
-            &copy; 2018
+            Hanami is a web framework for Ruby —
+            &copy; {{ now.Format "2006"}}
             <a href="https://lucaguidi.com" target="_blank"><span class="text-primary">Luca Guidi</span></a>
             </div>
           </div>

--- a/themes/hanami/layouts/partials/footer.html
+++ b/themes/hanami/layouts/partials/footer.html
@@ -44,8 +44,8 @@
     <div class="row align-items-center justify-content-md-between">
       <div class="col-md-6">
         <div class="copyright">
-          Hanami is a web framework for Ruby — 
-          &copy; 2018
+          Hanami is a web framework for Ruby —
+          &copy; {{ now.Format "2006"}}
           <a href="https://lucaguidi.com" target="_blank"><span class="text-primary">Luca Guidi</span></a>
         </div>
       </div>


### PR DESCRIPTION
I don't know where / if the footer file is used, but these were the two places where `2018` appeared. 

I know that, for copyright purposes, `2018` is fine but I think it looks better to have the most recent year in the footer.

Happy to change it to `2018`-`{current year}`, if you prefer (or earlier even)

(If you're reading this and new to Go, like I am, [`2006` is a special formatting value that means `%Y` in strftime](https://golang.org/pkg/time/#pkg-constants))