### PR TITLE
Improve design

### DIFF
--- a/themes/hanami/layouts/_default/single.html
+++ b/themes/hanami/layouts/_default/single.html
@@ -141,52 +141,54 @@
         </ul>
       </div>
       <main class="col-12 col-md-9 col-xl-8 py-md-3 pl-md-5 ct-content">
-        <div class="ct-page-title">
-          <h1 class="ct-title" id="content">{{ .Section | humanize | title }}: {{ .Title }}</h1>
-          <div class="avatar-group mt-3">
-          </div>
-        </div>
-        <hr>
-        {{ .Content }}
-
-        {{- $counter := 0 -}}
-        {{- $index := -1 -}}
-        {{- $pages := slice -}}
-        {{- range .Site.Params.topics -}}
-          {{- range sort (where $.Site.RegularPages "Section" .) ".Params.order" -}}
-            {{- $counter = add $counter 1 -}}
-            {{- if eq .URL $.Page.URL -}}
-            {{- $index = (sub $counter 1) -}}
-            {{- end -}}
-
-            {{- $pages = $pages | append . -}}
-          {{- end -}}
-        {{- end -}}
-        {{- $previousPage := index $pages (sub $index 1) -}}
-        {{- $nextPage := index $pages (add $index 1) -}}
-
-        <hr>
-        <div class="container">
-          <div class="row">
-            <div class="col">
-              {{ with $previousPage }}
-              <a href="{{ .URL }}">
-                <button class="btn btn-icon btn-3 btn-outline-primary" type="button">
-                  <span class="btn-inner--icon"><i class="ni ni-bold-left"></i></span>
-                  <span class="btn-inner--text">{{ .Section | humanize }}: {{ .Title }}</span>
-                </button>
-              </a>
-              {{ end }}
+        <div class="col-xl-8 mx-xl-auto">
+          <div class="ct-page-title">
+            <h1 class="ct-title" id="content">{{ .Section | humanize | title }}: {{ .Title }}</h1>
+            <div class="avatar-group mt-3">
             </div>
-            <div class="col text-align-right">
-              {{ with $nextPage }}
-              <a href="{{ .URL }}">
-                <button class="btn btn-icon btn-3 btn-outline-primary" type="button">
-                  <span class="btn-inner--text">{{ .Section | humanize }}: {{ .Title }}</span>
-                  <span class="btn-inner--icon"><i class="ni ni-bold-right"></i></span>
-                </button>
-              </a>
-              {{ end }}
+          </div>
+          <hr>
+          {{ .Content }}
+
+          {{- $counter := 0 -}}
+          {{- $index := -1 -}}
+          {{- $pages := slice -}}
+          {{- range .Site.Params.topics -}}
+            {{- range sort (where $.Site.RegularPages "Section" .) ".Params.order" -}}
+              {{- $counter = add $counter 1 -}}
+              {{- if eq .URL $.Page.URL -}}
+              {{- $index = (sub $counter 1) -}}
+              {{- end -}}
+
+              {{- $pages = $pages | append . -}}
+            {{- end -}}
+          {{- end -}}
+          {{- $previousPage := index $pages (sub $index 1) -}}
+          {{- $nextPage := index $pages (add $index 1) -}}
+
+          <hr>
+          <div class="container">
+            <div class="row">
+              <div class="col">
+                {{ with $previousPage }}
+                <a href="{{ .URL }}">
+                  <button class="btn btn-icon btn-3 btn-outline-primary" type="button">
+                    <span class="btn-inner--icon"><i class="ni ni-bold-left"></i></span>
+                    <span class="btn-inner--text">{{ .Section | humanize }}: {{ .Title }}</span>
+                  </button>
+                </a>
+                {{ end }}
+              </div>
+              <div class="col text-align-right">
+                {{ with $nextPage }}
+                <a href="{{ .URL }}">
+                  <button class="btn btn-icon btn-3 btn-outline-primary" type="button">
+                    <span class="btn-inner--text">{{ .Section | humanize }}: {{ .Title }}</span>
+                    <span class="btn-inner--icon"><i class="ni ni-bold-right"></i></span>
+                  </button>
+                </a>
+                {{ end }}
+              </div>
             </div>
           </div>
         </div>

--- a/themes/hanami/static/assets/css/theme.css
+++ b/themes/hanami/static/assets/css/theme.css
@@ -24,10 +24,9 @@ a:active {
 }
 
 code {
-  /* background-color: rgba(70,232,149, 0.5); */
-  background-color: rgba(255,216,66,.5);
+  background-color: rgba(255,216,66,.2);
   color: #525f7f;
-  padding: 0.2em 0.1em;
+  padding: 0.1em 0.1em 0 0.1em;
   font-family: monospace;
   font-size: 1.2em;
 }

--- a/themes/hanami/static/assets/css/theme.css
+++ b/themes/hanami/static/assets/css/theme.css
@@ -244,6 +244,7 @@ h6,
 
 main p {
   min-width: 100%;
+  line-height: inherit;
 }
 
 #secondary-navigation a:link,

--- a/themes/hanami/static/assets/css/theme.css
+++ b/themes/hanami/static/assets/css/theme.css
@@ -23,10 +23,6 @@ a:active {
   text-decoration: underline;
 }
 
-p {
-  font-size: 1.2rem;
-}
-
 code {
   /* background-color: rgba(70,232,149, 0.5); */
   background-color: rgba(255,216,66,.5);
@@ -180,6 +176,63 @@ header.navbar {
 
 div.highlight > pre {
   padding: 1em;
+}
+
+pre {
+  padding: 1px;
+}
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6,
+.h1,
+.h2,
+.h3,
+.h4,
+.h5,
+.h6
+{
+    padding-top: 1rem;
+    color: inherit;
+}
+
+h1,
+.h1
+{
+    font-size: 1.5rem;
+}
+
+h2,
+.h2
+{
+    font-size: 1.4rem;
+}
+
+h3,
+.h3
+{
+    font-size: 1.3rem;
+}
+
+h4,
+.h4
+{
+    font-size: 1.2rem;
+}
+
+h5,
+.h5
+{
+    font-size: 1.1rem;
+}
+
+h6,
+.h6
+{
+    font-size: 1rem;
 }
 
 #getting-started-lead {

--- a/themes/hanami/static/assets/css/theme.css
+++ b/themes/hanami/static/assets/css/theme.css
@@ -302,12 +302,14 @@ p.notice {
 
 p.convention {
   border-color: #46E895;
-  background-color: #46E895;
+  /* background-color: #46E895; */
+  background-color: rgba(70, 232, 149, 0.4);
 }
 
 p.warning {
   border-color: #fc7c5f;
-  background-color: #fc7c5f;
+  /* background-color: #fc7c5f; */
+  background-color: rgba(252, 124, 95, 0.4);
 }
 
 p.convention code,

--- a/themes/hanami/static/assets/css/theme.css
+++ b/themes/hanami/static/assets/css/theme.css
@@ -297,24 +297,23 @@ p.warning {
 
 p.notice {
   border-color: #35DDFF;
-  background-color: #35DDFF;
+  background-color: rgba(53, 221, 255, 0.4);
 }
 
 p.convention {
   border-color: #46E895;
-  /* background-color: #46E895; */
   background-color: rgba(70, 232, 149, 0.4);
 }
 
 p.warning {
   border-color: #fc7c5f;
-  /* background-color: #fc7c5f; */
   background-color: rgba(252, 124, 95, 0.4);
 }
 
+p.notice code,
 p.convention code,
 p.warning code {
-  background-color: rgba(255, 255, 255, 0.8);
+  background-color: rgba(245, 245, 245, 0.8);
 }
 
 span.ct-toc-link {

--- a/themes/hanami/static/assets/css/theme.css
+++ b/themes/hanami/static/assets/css/theme.css
@@ -238,6 +238,8 @@ h6,
   background-color: #f7f8f9;
   padding: 1em;
   min-width: 100%;
+  font-size: 1rem;
+  border-radius: 0.25rem;
 }
 
 main p {

--- a/themes/hanami/static/assets/css/theme.css
+++ b/themes/hanami/static/assets/css/theme.css
@@ -9,6 +9,7 @@
 body {
   color: #525f7f;
   position: relative;
+  font-family: var(--font-family-sans-serif);
 }
 
 a:link,

--- a/themes/hanami/static/assets/css/theme.css
+++ b/themes/hanami/static/assets/css/theme.css
@@ -243,7 +243,6 @@ h6,
 
 main p {
   min-width: 100%;
-  text-align: justify;
 }
 
 #secondary-navigation a:link,


### PR DESCRIPTION
Before:
<img width="1920" alt="image" src="https://user-images.githubusercontent.com/632942/115078902-90c88500-9ebd-11eb-8116-d21a2f2dfcdc.png">


After:
<img width="1920" alt="image" src="https://user-images.githubusercontent.com/632942/115082898-dc7e2d00-9ec3-11eb-8127-227d8f10f7f7.png">

These screenshots are 1920px wide. 
Displayed on a 27 inch monitor:
- Before: the main column is ~28cm (11 inches) wide. ~125 characters per line
- After: the main column is ~20cm (8 inches) wide. ~100-110 characters per line

This is still much higher than the recommended maximum number of characters per line (~75-80) but I think it looks fine. Happy to make the column even narrower. Right now we get ~20% more content per screen with this design, and that'll be reduced if the content is narrower.

You can walk through the commit messages to see the details of what was changed. But some highlights:
- Narrow the width of the content to 2/3rds of the center column rather than 100%
- Change font from Open Sans to the OS native stack. This is a very common practice now.
- Lower size from 1.2rem (19.2px) to 1rem (16px).
- Make the notice/warning/convention color less intense by adding transparency.
- Make the code-highlighting (yellow background) less intense, and reduce padding too.

A couple things:

- I wrapped the main content in another div to keep the fixed sidebar all the way on the right side where it belongs. Another way to do this is to create empty divs that only have width at xl (and larger) width. The approach I did here of having an internal column system that's centered and 8/12 wide seems to work fine though.

- ~For some reason my local `hugo` doesn't render any of the embedded HTML that we use in markdown for  `<p>` tags with classes `notice`, `warning`, or `convention`. I'm not sure why this happens, but I guess it might be related to having a newer hugo version than the build server uses? I did update those colors, by changing them in the web inspector on the production site, to make sure the colors look good. I can make sure those render once this is merged.~ UPDATE: This is all still true but it generated fine with the preview from Netlify, so I think we'lll be all set.


Happy to revisit any of these, or look at any other parts of the design.

(Edit: Closes #84)