### PR TITLE
Enable unsafe markdown rendering

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -9,6 +9,9 @@ pygmentscodefences = true
 pygmentsuseclasses = false
 pygmentsstyle = "monokailight"
 
+[markup.goldmark.renderer]
+  unsafe = true
+
 [permalinks]
   posts = "/:slug/"
 


### PR DESCRIPTION
Hugo 0.60.0 switched Markdown engines, and now unsafe
rendering must be enabled manually.

https://gohugo.io/news/0.60.0-relnotes/

Fixes issues where raw HTML is excluded from rendering

![image](https://user-images.githubusercontent.com/17083/121448893-98a92080-c966-11eb-884b-11377f85c70e.png)

Reported by @swilgosz 