### PR TITLE
Update getting started guide

### DIFF
--- a/content/v1.3/introduction/getting-started.md
+++ b/content/v1.3/introduction/getting-started.md
@@ -923,7 +923,7 @@ To make our tests pass, we need to implement validations.
 Although you can add validation rules to the entity, Hanami also allows you to define validation rules as close to the source of the input as possible, i.e., the action.
 Hanami controller actions can use the `params` class method to define acceptable incoming parameters.
 
-This approach both whitelists what `params` are used (others are discarded to prevent mass-assignment vulnerabilities from untrusted user input) _and_ adds rules to define what values are acceptable — in this case, we've specified that the nested attributes for a book's title and author should be present.
+This approach both explicitly declares which `params` are allowed (others are discarded to prevent mass-assignment vulnerabilities from untrusted user input) _and_ it adds rules to define which values are acceptable — in this case, we've specified that the nested attributes for a book's title and author should be non-empty strings.
 
 With our validations in place, we can limit our entity creation and redirection to cases where the incoming `params` are valid:
 

--- a/content/v1.3/introduction/getting-started.md
+++ b/content/v1.3/introduction/getting-started.md
@@ -296,12 +296,12 @@ This test means that when we go to [/books](http://localhost:2300/books),
 we'll see two HTML elements that have class `book`,
 and both will be inside of an HTML element that has an id of `books`.
 
-Our test suite is `Unable to find visible css "#books"`.
+Our test suite shows 1 failure: `Unable to find visible css "#books"`.
 
 Not only are we missing that element,
 we don't even have a page to put that element on!
 
-Let's create a new action to fix that.
+Let's create a new action and a new route to fix that.
 
 ### Hanami Generators
 
@@ -392,8 +392,8 @@ Let's edit `apps/web/templates/application.html.erb` to look like this:
 </html>
 ```
 
-And remove the duplicate lines from the other templates,
-since they're duplicated now.
+And remove the `<h1>Bookshelf</h1>` line from the other template (`apps/web/templates/home/index.html.erb`),
+so it's not duplicated.
 
 A **layout template** is like any other template, but it is used to wrap your regular templates.
 The `yield` line is replaced with the contents of our regular template.

--- a/content/v1.3/introduction/getting-started.md
+++ b/content/v1.3/introduction/getting-started.md
@@ -1037,10 +1037,14 @@ RSpec.describe 'Add a book' do
 end
 ```
 
+Now we have two failing tests, but that's OK. It's simple to fix them.
+
 In our template, we can loop over `params.error_messages` (if there are any) and display a friendly message.
-Open up `apps/web/templates/books/new.html.erb`:
+Open up `apps/web/templates/books/new.html.erb` and add this between the `<h2>` and the form.
 
 ```erb
+# apps/web/templates/books/new.html.erb, in the middle
+<%# ... $>
 <% unless params.valid? %>
   <div class="errors">
     <h3>There was a problem with your submission</h3>
@@ -1051,6 +1055,7 @@ Open up `apps/web/templates/books/new.html.erb`:
     </ul>
   </div>
 <% end %>
+<%# ... $>
 ```
 
 Run your tests again and see they are all passing again!

--- a/content/v1.3/introduction/getting-started.md
+++ b/content/v1.3/introduction/getting-started.md
@@ -510,13 +510,13 @@ We can use Hanami's `console` command to launch `irb` with our application pre-l
 ```shell
 $ bundle exec hanami console
 >> repository = BookRepository.new
-=> #<BookRepository relations=[:books]>
+  # => #<BookRepository relations=[:books]>
 >> repository.all
-=> []
+  # => []
 >> book = repository.create(title: 'TDD', author: 'Kent Beck')
-=> #<Book:0x007f9ab61c23b8 @attributes={:id=>1, :title=>"TDD", :author=>"Kent Beck", :created_at=>2018-10-24 11:11:38 UTC, :updated_at=>2018-10-24 11:11:38 UTC}>
+  # => #<Book:0x007f9ab61c23b8 @attributes={:id=>1, :title=>"TDD", :author=>"Kent Beck", :created_at=>2018-10-24 11:11:38 UTC, :updated_at=>2018-10-24 11:11:38 UTC}>
 >> repository.find(book.id)
-=> #<Book:0x007f9ab6181610 @attributes={:id=>1, :title=>"TDD", :author=>"Kent Beck", :created_at=>2018-10-24 11:11:38 UTC, :updated_at=>2018-10-24 11:11:38 UTC}>
+  # => #<Book:0x007f9ab6181610 @attributes={:id=>1, :title=>"TDD", :author=>"Kent Beck", :created_at=>2018-10-24 11:11:38 UTC, :updated_at=>2018-10-24 11:11:38 UTC}>
 ```
 
 Hanami repositories have methods to load one or more entities from our database, and to create and update existing records.

--- a/content/v1.3/introduction/getting-started.md
+++ b/content/v1.3/introduction/getting-started.md
@@ -523,7 +523,7 @@ Hanami repositories have methods to load one or more entities from our database,
 The repository is also the place where you would define new methods to implement custom queries.
 
 To recap, we've seen how Hanami uses entities and repositories to model our data.
-Entities represent our behavior, while repositories use mappings to translate our entities to our data store.
+Entities represent our behavior, while repositories use mappings to translate our entities to and from our data store.
 We can use migrations to apply changes to our database schema.
 
 ### Displaying Dynamic Data

--- a/content/v1.3/introduction/getting-started.md
+++ b/content/v1.3/introduction/getting-started.md
@@ -847,18 +847,14 @@ This minimal implementation should suffice to make our tests pass.
 
 ```shell
 $ bundle exec rake
-Run options: --seed 63592
+........
 
-# Running:
-
-...............
-
-Finished in 0.081961s, 183.0142 runs/s, 305.0236 assertions/s.
-
-12 runs, 14 assertions, 0 failures, 0 errors, 2 skips
+Finished in 0.07168 seconds (files took 1.4 seconds to load)
+16 examples, 0 failures
 ```
 
 Congratulations!
+We've created a simple web app action to add a book to a databse.
 
 ### Securing Our Form With Validations
 

--- a/content/v1.3/introduction/getting-started.md
+++ b/content/v1.3/introduction/getting-started.md
@@ -1062,15 +1062,9 @@ Run your tests again and see they are all passing again!
 
 ```shell
 $ bundle exec rake
-Run options: --seed 59940
-
-# Running:
-
-..................
-
-Finished in 0.078112s, 230.4372 runs/s, 473.6765 assertions/s.
-
-15 runs, 27 assertions, 0 failures, 0 errors, 1 skips
+........
+Finished in 0.07811 seconds (files took 1.35 seconds to load)
+18 examples, 0 failures
 ```
 
 ### Improving Our Use Of The Router
@@ -1115,6 +1109,8 @@ Remember how we built our form using `form_for`?
 # apps/web/templates/books/new.html.erb
 <h2>Add book</h2>
 
+<%# ... %>
+
 <%=
   form_for :book, '/books' do
     # ...
@@ -1128,6 +1124,8 @@ We can use the `routes` helper method that is available in our views and actions
 ```erb
 # apps/web/templates/books/new.html.erb
 <h2>Add book</h2>
+
+<%# ... %>
 
 <%=
   form_for :book, routes.books_path do

--- a/content/v1.3/introduction/getting-started.md
+++ b/content/v1.3/introduction/getting-started.md
@@ -131,7 +131,7 @@ Hanami doesn't want us to [repeat ourselves](https://en.wikipedia.org/wiki/Don%2
 Web applications almost always store and interact with data stored in a database.
 Both our "business logic" and our persistence live in `lib/`.
 
-_(Hanami architecture is heavily inspired by [Clean Architecture](https://blog.8thlight.com/uncle-bob/2012/08/13/the-clean-architecture.html).)_
+_(Hanami architecture is heavily inspired by [Hexagonal architecture](https://en.wikipedia.org/wiki/Hexagonal_architecture_(software))._)
 
 ## Writing Our First Test
 

--- a/content/v1.3/introduction/getting-started.md
+++ b/content/v1.3/introduction/getting-started.md
@@ -988,7 +988,9 @@ Run your tests again and see they are all passing again!
 
 ### Displaying Validation Errors
 
-Rather than just shoving the user a form under their nose when something has gone wrong, we should give them a hint of what's expected of them. Let's adapt our form to show a notice about invalid fields.
+Rather than just showing the user the same form they entered when something has gone wrong,
+we should give them a hint of what's actually expected of them.
+Let's adapt our form to show a notice about invalid field values.
 
 First, we expect a list of errors to be included in the page when `params` contains errors:
 

--- a/content/v1.3/introduction/getting-started.md
+++ b/content/v1.3/introduction/getting-started.md
@@ -554,8 +554,10 @@ RSpec.describe 'List books' do
 end
 ```
 
-We create the required records in our test and then assert the correct number of book classes on the page.
-When we run this test, it should pass. If it does not pass, a likely reason is that the test database was not migrated.
+We create a single Book record in our test and then assert that the title and author are displayed on the page.
+When we run this test, it will fail.
+This is because we haven't updated our template yet,
+it still has the hard-coded books from earlier.
 
 Now we can change our template and remove the static HTML.
 Our view needs to loop over all available records and render them.
@@ -598,11 +600,12 @@ RSpec.describe Web::Views::Books::Index do
 end
 ```
 
-We specify that our index page will show a simple placeholder message when there are no books to display; when there are, it lists every one of them.
+We specify that our index page will show a simple placeholder message when there are no books to display;
+when there are books, it lists every one of them.
 Note how rendering a view with some data is relatively straight-forward.
 Hanami is designed around simple objects with minimal interfaces that are easy to test in isolation, yet still work great together.
 
-Let's rewrite our template to implement these requirements:
+Now we have 3 failing tests, but we can fix them by rewriting our template to implement these requirements:
 
 ```erb
 # apps/web/templates/books/index.html.erb
@@ -653,7 +656,7 @@ RSpec.describe Web::Controllers::Books::Index do
 end
 ```
 
-Writing tests for controller actions is basically two-fold: you either assert on the response object, which is a Rack-compatible array of status, headers, and content; or on the action itself, which will contain exposures after we've called it.
+Writing tests for controller actions gives you two possible things to test: you either assert on the response object, which is a Rack-compatible array of status, headers, and content; or on the action itself, which will contain exposures after we've called it.
 Now we've specified that the action exposes `:books`, we can implement our action:
 
 ```ruby

--- a/content/v1.3/introduction/getting-started.md
+++ b/content/v1.3/introduction/getting-started.md
@@ -1137,8 +1137,21 @@ We can use the `routes` helper method that is available in our views and actions
 We can make a similar change in `apps/web/controllers/books/create.rb`:
 
 ```ruby
+...
 redirect_to routes.books_path
+...
 ```
+
+and in `apps/web/templates/books/index.html.erb`:
+
+```erb
+...
+<a href="<%= routes.new_book_path %>">New book</a>
+...
+```
+
+(You could also extend this to the specs if you'd like,
+but changing the path can affect users so you may want to repeat yourself there.)
 
 ## Wrapping Up
 

--- a/content/v1.3/introduction/getting-started.md
+++ b/content/v1.3/introduction/getting-started.md
@@ -473,7 +473,9 @@ $ HANAMI_ENV=test bundle exec hanami db prepare
 ### Working With Entities
 
 An entity is something really close to a plain Ruby object.
-We should focus on the behaviors that we want from it and only then, how to save it.
+With them, we model the behavior we want from a concept (a book, in this case).
+They're decoupled from _persistence_ entirely, but they're easy to persist and
+retrieve, we'll soon see.
 
 For now, we need to create a simple entity class:
 
@@ -491,11 +493,14 @@ We can verify it all works as expected with a unit test:
 
 RSpec.describe Book do
   it 'can be initialized with attributes' do
-    book = Book.new(title: 'Refactoring')
+    book = Book.new(title: 'Refactoring', author: 'Martin Fowler')
     expect(book.title).to eq('Refactoring')
+    expect(book.author).to eq('Martin Fowler')
   end
 end
 ```
+
+(Generally we recommend against 'testing the framework' like this, but it's useful here to demonstrate how Entities work in Hanami.)
 
 ### Using Repositories
 

--- a/content/v1.3/introduction/getting-started.md
+++ b/content/v1.3/introduction/getting-started.md
@@ -683,15 +683,10 @@ That's enough to make all our tests pass again!
 
 ```shell
 $ bundle exec rake
-Run options: --seed 59133
+......
 
-# Running:
-
-.........
-
-Finished in 0.042065s, 213.9543 runs/s, 380.3633 assertions/s.
-
-6 runs, 7 assertions, 0 failures, 0 errors, 0 skips
+Finished in 0.03745 seconds (files took 1.34 seconds to load)
+10 examples, 0 failures
 ```
 
 ## Building Forms To Create Records


### PR DESCRIPTION
The main change I wanted to make here was that I realized our spec [where we introduce dynamic data was a false positive](https://github.com/hanami/guides/blob/main/content/v1.3/introduction/getting-started.md#displaying-dynamic-data). That's a bad practice for Behavior Driven Development, so I changed the spec to be a single book, and check for the actual content, rather than a CSS selector and count. This is more robust.

I also changed the link from "Clean architecture" to "Hexagonal architecture". The latter has a wikipedia page and it gets the underlying idea across well enough. (Plus we want to distance ourselves from Robert Martin, who drafted the post we are currently linking too.)

In the process, I went through the whole guide and cleaned up many pretty small things.