### PR TITLE
Add `BRANCH` env variable to allowed getenv params

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -29,3 +29,6 @@ pygmentsstyle = "monokailight"
   github = "hanami/hanami"
   keywords = "hanami,hanamirb,hanami guides,documentation,lotus,lotusrb,web,framework,ruby,open source,oss,os,software,free,free software,architecture,fast,lightweight,testing,tdd,bdd,test driven development,behaviour driven development,full stack,mvc,model view object,pattern,patterns,design patterns,oop,object oriented programming,testability,http,https,routing,router,http router,restful,resource,resources,convention,controller,models,repository,query,sql,interactors,two-step view,view,template,presenters,render,rendering,helpers,erb,haml,tilt,json,xml,yaml,yml,framwork,framewrok,riby,free sowftare"
   githubrepo = "https://github.com/hanami/guides"
+
+[security.funcs]
+  getenv = ['^HUGO_', 'BRANCH']


### PR DESCRIPTION
One of the newer Hugo releases has increased security around the `getenv` function, and it prevents the callout to the `BRANCH` env variable on newer releases of Hugo, preventing builds.