### PR TITLE
Provide warning to developers using Ruby 3.0

### DIFF
--- a/content/v1.3/introduction/getting-started.md
+++ b/content/v1.3/introduction/getting-started.md
@@ -66,6 +66,9 @@ Then we can use the new `hanami` executable to generate a new project:
 $ gem install hanami
 $ hanami new bookshelf
 ```
+<p class="notice">
+  Hanami 1 doesn't support Ruby 3. If you run into problems use Ruby 2.7.
+</p>
 
 <p class="notice">
   By default, the project will be setup to use a SQLite database. For real-world projects, you can specify your engine:


### PR DESCRIPTION
Hanami currently doesn't support Ruby 3.0, but we must assume that developers will have the latest version of ruby when reading and using the Getting Started Docs. This warning should help developers that encounter an immediate error quickly switch down to Ruby 2.7 to keep going. Alternatively we could also suggest using Hanamie 2.0 by forcing a gem install of the latest alpha version: `gem install hanami -v 2.0.0.alpha7`.