### PR TITLE
Fix minor typo

### DIFF
--- a/content/v1.3/architecture/interactors.md
+++ b/content/v1.3/architecture/interactors.md
@@ -272,7 +272,7 @@ To make this test pass, we'll need to create a _persisted_ `Book` instead.
 Edit the `call` method in our `lib/bookshelf/interactors/add_book.rb` interactor:
 
 ```ruby
-def call
+def call(book_attributes)
   @book = BookRepository.new.create(book_attributes)
 end
 ```


### PR DESCRIPTION
Fix little error in the guide:

```ruby
def call
  @book = BookRepository.new.create(book_attributes)
end
```

should be

```ruby
def call(book_attributes)
  @book = BookRepository.new.create(book_attributes)
end
```
