### PR TITLE
Remove text-align: justify; from main p

### DIFF
--- a/themes/hanami/static/assets/css/theme.css
+++ b/themes/hanami/static/assets/css/theme.css
@@ -189,7 +189,6 @@ div.highlight > pre {
 
 main p {
   min-width: 100%;
-  text-align: justify;
 }
 
 #secondary-navigation a:link,


### PR DESCRIPTION
There are some text spacing issues in the guides that I found distracting. `text-align: justify` seems to be the culprit. I'm not sure what the original intent for the style was, so this change may have consequences elsewhere that I'm not aware of.

**GIF**
![screencast 2022-05-20 15-43-13](https://user-images.githubusercontent.com/1964212/169621500-b6990e5b-4171-4b3f-b462-ba9e7642c25c.gif)
