### PR TITLE
v1.3 - Fix a broken link

### DIFF
--- a/content/v1.3/routing/overview.md
+++ b/content/v1.3/routing/overview.md
@@ -39,7 +39,7 @@ options '/hello', to: endpoint
 
 ## Rack
 
-Hanami is compatible with [Rack SPEC](http://www.rubydoc.info/github/rack/rack/master/file/SPEC), and so the endpoints that we use MUST be compliant as well.
+Hanami is compatible with [Rack SPEC](https://www.rubydoc.info/github/rack/rack/main/file/SPEC.rdoc), and so the endpoints that we use MUST be compliant as well.
 In the example above we used a `Proc` that was fitting our requirements.
 
 A valid endpoint can be an object, a class, an action, or an **application** that responds to `#call`.


### PR DESCRIPTION
It looks like the `rack/rack` project changed the name of their default branch, and that the link needs the file's extension to be viewable.

The corrected link is available here:  https://deploy-preview-110--hanami-guides.netlify.app/v1.3/routing/overview/#rack