### PR TITLE
fix: Correction of or notation in where clause

### DIFF
--- a/content/v1.3/repositories/sql-queries.md
+++ b/content/v1.3/repositories/sql-queries.md
@@ -89,7 +89,7 @@ class UserRepository < Hanami::Repository
   end
 
   def by_id_min_max(min, max)
-    users.where { id > min || id < max }
+    users.where { id > min | id < max }
   end
 
   def by_not_id(input)


### PR DESCRIPTION
url: https://guides.hanamirb.org/v1.3/repositories/sql-queries/#sql-functions
method: by_id_min_max

I think | is one way to use or in the where clause.
Please confirm. thank you.

ref: https://rom-rb.org/learn/sql/3.3/queries/#complex-conditions