### PR TITLE
Navigation version switch

### DIFF
--- a/themes/hanami/layouts/_default/single.html
+++ b/themes/hanami/layouts/_default/single.html
@@ -62,6 +62,15 @@
       <div class="d-none d-sm-block ml-auto">
         <ul class="navbar-nav ct-navbar-nav flex-row align-items-center">
           <li class="nav-item">
+            <select id="navigation-version-switch" class="form-control">
+              {{ $currentSection := .Section}}
+              {{ range .Site.Sections }}
+                {{ $title := replace .RelPermalink "/" "" }}
+                <option value="{{ .Permalink }}" {{ if eq .Section $currentSection}}selected{{end}}>{{ $title }}</option>
+              {{ end }}
+            </select>
+          </li>
+          <li class="nav-item">
             <a class="nav-link nav-link-icon" href="http://hanamirb.org" target="_blank" title="Hanami website">
               <i class="ni ni-world"></i>
             </a>

--- a/themes/hanami/static/assets/js/theme.js
+++ b/themes/hanami/static/assets/js/theme.js
@@ -1,5 +1,11 @@
 (function($){
   $(document).ready(function(){
+    // Navigation Documentation Version Select switch
+    $('#navigation-version-switch').change(function (event) {
+      var url = $(event.target).val()
+      window.location.replace(url)
+    })
+
     // Search link
     $("#search-link").click(function(event) {
       event.preventDefault();


### PR DESCRIPTION
# Enhancement

Show in navigation bar a select to pick the versions of the documentation.
Once a reader changes the value of the select, they will be redirected to the requested version of the documentation.

The values of the select (the `<option>` tags) are automatically picked by the code, by looking at the `content/` directory. This is the directory where we'll have multiple versions of the documentation (e.g. `content/v1.3`, `content/v2.0`, etc..).

The page is rendered with selected `<option>`, according to the current section (e.g. v1.3)

---

![Screenshot 2022-10-06 at 14 56 19](https://user-images.githubusercontent.com/5089/194318444-4a90a2cb-9345-45b2-8f20-8e996deea287.png)
