### PR TITLE
Docs/309 actions sessions and cookies

### DIFF
--- a/content/v2.0/actions/cookies.md
+++ b/content/v2.0/actions/cookies.md
@@ -62,7 +62,7 @@ module Bookshelf
 end
 ```
 
-This configuration can be overridden on an as needs basis passing a hash, which has a `value` key representing the value of the cookie, and any properties to override.
+This configuration can be overridden within an action passing a hash, which has a `value` key representing the value of the cookie, and any properties to override.
 
 ```ruby
 module Bookshelf

--- a/content/v2.0/actions/cookies.md
+++ b/content/v2.0/actions/cookies.md
@@ -47,6 +47,13 @@ module Bookshelf
           response.cookies[:b]         # read
           response.cookies[:a] = 'foo' # assign
           response.cookies[:c] = nil   # remove
+          
+          # overrides options
+          response.cookies[:d] = { 
+            value: 'foo', 
+            path: '/books', 
+            max_age: 100 
+          }
         end
       end
     end
@@ -54,4 +61,5 @@ module Bookshelf
 end
 ```
 
-When setting a value, a cookie can accept a `String`
+When setting a value, a cookie can accept a `String` or a `Hash` to specify inline options.
+General settings are applied automatically but these options can be used to override values case by case.

--- a/content/v2.0/actions/cookies.md
+++ b/content/v2.0/actions/cookies.md
@@ -19,7 +19,7 @@ module Bookshelf
 end
 ```
 
-Cookies subsequently sent by the browser can be read from the request.
+Cookies subsequently sent by the browser can be read from the `request`.
 
 ```ruby
 module Bookshelf

--- a/content/v2.0/actions/cookies.md
+++ b/content/v2.0/actions/cookies.md
@@ -1,0 +1,57 @@
+---
+title: Cookies
+order: 80
+---
+
+## Enable Cookies
+
+Hanami applies _"batteries included, but not installed"_ philosophy.
+Cookies are a feature that is present but needs to be activated.
+
+In our application settings there is a line to uncomment.
+
+```ruby
+# config/app.rb
+
+module Bookshelf
+  class Application < Hanami::Application
+    config.actions.cookies = { max_age: 300 }
+  end
+end
+```
+
+From now on, cookies are automatically sent for each response.
+
+## Settings
+
+With that configuration we can specify options that will be set for all cookies we send from our application.
+
+  * `:domain` - `String` (`nil` by default), the domain
+  * `:path` - `String` (`nil` by default), a relative URL
+  * `:max_age` - `Integer` (`nil` by default), cookie duration expressed in seconds
+  * `:secure` - `Boolean` (`true` by default if using SSL), restrict cookies to secure connections
+  * `:httponly` - `Boolean` (`true` by default), restrict JavaScript access to cookies
+
+## Usage
+
+Cookies behave like a `Hash`: we can read, assign and remove values.
+
+```ruby
+# app/actions/books/index.rb
+
+module Bookshelf
+  module Actions
+    module Books
+      class Index < Bookshelf::Action
+        def handle(request, response)
+          response.cookies[:b]         # read
+          response.cookies[:a] = 'foo' # assign
+          response.cookies[:c] = nil   # remove
+        end
+      end
+    end
+  end
+end
+```
+
+When setting a value, a cookie can accept a `String`

--- a/content/v2.0/actions/sessions.md
+++ b/content/v2.0/actions/sessions.md
@@ -3,56 +3,52 @@ title: Sessions
 order: 90
 ---
 
-## Enable Sessions
-
-Sessions are available in Hanami applications, but not enabled by default.
-If we want to turn on this feature, we just need to uncomment a line of code.
+Sessions are disabled by default. To enable sessions, add a config like the following to your app:
 
 ```ruby
 # config/app.rb
 
 module Bookshelf
   class App < Hanami::App
-    config.actions.sessions = :cookie, secret: ENV['WEB_SESSIONS_SECRET']
-    end
+    config.actions.sessions = :cookie, {
+      key: "bookshelf.session",
+      secret: settings.session_secret,
+      expire_after: 60*60*24*365
+    }
   end
 end
 ```
 
-The first argument is the name of the adapter for the session storage.
-The default value is `:cookie`, that uses `Rack::Session::Cookie`.
-
-<p class="convention">
-The name of the session adapter is the underscored version of the class name under <code>Rack::Session</code> namespace.
-Example: <code>:cookie</code> for <code>Rack::Session::Cookie</code>.
-</p>
-
-We can use a different storage compatible with Rack sessions.
-Let's say we want to use Redis. We should bundle `redis-rack` and specify the name of the adapter: `:redis`.
-Hanami is able to autoload the adapter and use it when the application is started.
-
-<p class="convention">
-Custom storage technologies can be loaded via <code>require "rack/session/#{ adapter_name }"</code>.
-</p>
-
-The second argument passed to `sessions` is a Hash of options that are **passed to the adapter**.
-We find only a default `:secret`, but we can specify all the values that are supported by the chosen adapter.
-
-## Usage
-
-Sessions behave like a Hash: we can read, assign and remove values.
+For this to work, you will need to add a `session_secret` to your app settings. See [settings](/v2.0/app/settings/) for more details.
 
 ```ruby
-# app/actions/books/index.rb
+# config/settings.rb
+
+module Bookshelf
+  class Settings < Hanami::Settings
+    setting :session_secret, constructor: Types::String
+  end
+end
+```
+## Using sessions
+
+With sessions enabled, actions can set and read values from the session using the `response` and `request` objects.
+
+```ruby
 
 module Bookshelf
   module Actions
     module Books
       class Index < Bookshelf::Action
         def handle(request, response)
-          response.session[:b]         # read
-          response.session[:a] = 'foo' # assign
-          response.session[:c] = nil   # remove
+          # Setting a value in the session
+          response.session[:user_id] = 1
+
+          # Reading a value from the session
+          request.session[:user_id] # => 1
+
+          # Removing a value from the session
+          request.session[:user_id] = nil
         end
       end
     end
@@ -60,48 +56,22 @@ module Bookshelf
 end
 ```
 
-### Sharing session values between slices
+## Session adapters
 
-To share session values, defined in one slice, we must provide the same session secret to all the slices where we need those values.
+When configuring sessions, the first argument of the configuration is the adapter to use for session storage.
 
-```ruby
-# Define ENV variables for development environment
-Main_SESSIONS_SECRET="123456789"
-ADMIN_SESSIONS_SECRET="123456789"
-```
+Specifying `:cookie`, as above, will use `Rack::Session::Cookie` for the session storage.
 
-Set session variable in the first slice.
 
-```ruby
-# slices/main/books/index.rb
+<p class="convention">
+The name of the session adapter is the underscored version of the class name under <code>Rack::Session</code> namespace.
+Example: <code>:cookie</code> for <code>Rack::Session::Cookie</code>.
+</p>
 
-module Main
-  module Actions
-    module Books
-      class Index < Main::Action
-        def handle(request, response)
-          response.session[:foo] = 'bar' # assign
-        end
-      end
-    end
-  end
-end
-```
+To use a different adapter, for example `:redis`, add the `redis-rack` gem and specify the adapter as `:redis`.
 
-Read session variable in the second app.
+<p class="convention">
+Custom storage technologies can be loaded via <code>require "rack/session/#{ adapter_name }"</code>.
+</p>
 
-```ruby
-# slices/admin/books/index.rb
-
-module Admin
-  module Actions
-    module Books
-      class Index < Main::Action
-        def handle(request, response)
-          puts response.session[:foo] # read => 'bar'
-        end
-      end
-    end
-  end
-end
-```
+The second argument passed to `sessions` is a hash of options to be passed to the chosen adapter.

--- a/content/v2.0/actions/sessions.md
+++ b/content/v2.0/actions/sessions.md
@@ -1,0 +1,107 @@
+---
+title: Sessions
+order: 90
+---
+
+## Enable Sessions
+
+Sessions are available in Hanami applications, but not enabled by default.
+If we want to turn on this feature, we just need to uncomment a line of code.
+
+```ruby
+# config/app.rb
+
+module Bookshelf
+  class App < Hanami::App
+    config.actions.sessions = :cookie, secret: ENV['WEB_SESSIONS_SECRET']
+    end
+  end
+end
+```
+
+The first argument is the name of the adapter for the session storage.
+The default value is `:cookie`, that uses `Rack::Session::Cookie`.
+
+<p class="convention">
+The name of the session adapter is the underscored version of the class name under <code>Rack::Session</code> namespace.
+Example: <code>:cookie</code> for <code>Rack::Session::Cookie</code>.
+</p>
+
+We can use a different storage compatible with Rack sessions.
+Let's say we want to use Redis. We should bundle `redis-rack` and specify the name of the adapter: `:redis`.
+Hanami is able to autoload the adapter and use it when the application is started.
+
+<p class="convention">
+Custom storage technologies can be loaded via <code>require "rack/session/#{ adapter_name }"</code>.
+</p>
+
+The second argument passed to `sessions` is a Hash of options that are **passed to the adapter**.
+We find only a default `:secret`, but we can specify all the values that are supported by the chosen adapter.
+
+## Usage
+
+Sessions behave like a Hash: we can read, assign and remove values.
+
+```ruby
+# app/actions/books/index.rb
+
+module Bookshelf
+  module Actions
+    module Books
+      class Index < Bookshelf::Action
+        def handle(request, response)
+          response.session[:b]         # read
+          response.session[:a] = 'foo' # assign
+          response.session[:c] = nil   # remove
+        end
+      end
+    end
+  end
+end
+```
+
+### Sharing session values between slices
+
+To share session values, defined in one slice, we must provide the same session secret to all the slices where we need those values.
+
+```ruby
+# Define ENV variables for development environment
+Main_SESSIONS_SECRET="123456789"
+ADMIN_SESSIONS_SECRET="123456789"
+```
+
+Set session variable in the first slice.
+
+```ruby
+# slices/main/books/index.rb
+
+module Main
+  module Actions
+    module Books
+      class Index < Main::Action
+        def handle(request, response)
+          response.session[:foo] = 'bar' # assign
+        end
+      end
+    end
+  end
+end
+```
+
+Read session variable in the second app.
+
+```ruby
+# slices/admin/books/index.rb
+
+module Admin
+  module Actions
+    module Books
+      class Index < Main::Action
+        def handle(request, response)
+          puts response.session[:foo] # read => 'bar'
+        end
+      end
+    end
+  end
+end
+```


### PR DESCRIPTION
Resolves: https://trello.com/c/2o4s5kK4/309-actions-sessions-and-cookies

Covers both:
- cookies 
- sessions


### Caevats

In 1.3 guides, we'd got an option to set `has-like` values, where we could override default options for specific cookie. I could not make it working here. [Slack thread](https://hanamiruby.slack.com/archives/C020Q5P0A2E/p1668987432080189?thread_ts=1668984305.562539&cid=C020Q5P0A2E)