### PR TITLE
Tweak CSS a bit

### DIFF
--- a/content/v2.0/logger/configuration.md
+++ b/content/v2.0/logger/configuration.md
@@ -11,7 +11,7 @@ You can tweak its configuration in your `App` class, but typically, the defaults
 - In `test` environment logger logs to `logs/test.log` in `:debug` mode
 - In `production` environment logger logs to `$stdout` in `:info` mode using `:json` formatter
 
-# Changing default config
+### Changing default config
 
 The logger configuration is namespaced as `config.logger` and you can access it in your `App` class. If you change these settings, they will be set *for all environments by default*.
 
@@ -46,7 +46,7 @@ module Bookshelf
 end
 ```
 
-# Log filters
+### Log filters
 
 In order to avoid having sensitive information leak to your log streams, Hanami configures log filtering to filter out the following keys:
 
@@ -68,7 +68,7 @@ module Bookshelf
 end
 ```
 
-# Colorized output
+### Colorized output
 
 If you want colorized log levels in your output, you can do so via `colorize` option:
 
@@ -106,7 +106,7 @@ module Bookshelf
 end
 ```
 
-# Customizing logging destinations
+### Customizing logging destinations
 
 You may want to handle certain type of log entries in a special way. One example of this could be logging unexpected crashes to a special file to be able to see them more easily when running tests. You can achieve this by adding a dedicated logging backend.
 

--- a/content/v2.0/logger/usage.md
+++ b/content/v2.0/logger/usage.md
@@ -7,7 +7,7 @@ Hanami logger is compatible with the stdlib `Logger` but it supports structured 
 
 In non-production environments, structured logs are turned into easy read text log entries, but the underlying log entries are represented as struct-like objects, even if you pass a text message to your logger.
 
-# Basic usage
+### Basic usage
 
 To log a text entry, simply use a logger method with a name corresponding to the log level that you want to use. Let's say you want to log an entry with `INFO` level:
 
@@ -31,7 +31,7 @@ The following logging methods are available:
 - `error`
 - `fatal`
 
-# Logging data
+### Logging data
 
 In addition to plain text logging, you can log arbitrary data by passing a log entry *payload* to a log method:
 
@@ -49,7 +49,7 @@ bookshelf[development]> app["logger"].info text: "Hello World", component: "admi
 
 Notice that the default development log formatting turns our payload into a `key=value` representation. It's easy to read or even parse programatically, but please remember that in any environment where logs are parsed and post-processing **using JSON** format is the recommended way, and this is how Hanami configures its logger in `production` environment by default.
 
-# Logging exceptions
+### Logging exceptions
 
 Hanami logger supports logging exceptions out of the box without the need to write custom formatters. Simply rescue from an exception and pass it to the `error` log method:
 

--- a/themes/hanami/static/assets/css/theme.css
+++ b/themes/hanami/static/assets/css/theme.css
@@ -23,7 +23,7 @@ a:active {
 }
 
 p {
-  font-size: 1.2rem;
+  font-size: 1.0rem;
 }
 
 code {
@@ -31,7 +31,7 @@ code {
   color: #525f7f;
   padding: 0.2em 0.1em;
   font-family: monospace;
-  font-size: 1.2em;
+  font-size: 1.0em;
 }
 
 #search-form {

--- a/themes/hanami/static/assets/css/theme.css
+++ b/themes/hanami/static/assets/css/theme.css
@@ -7,8 +7,9 @@
  */
 
 body {
-  color: #525f7f;
+  color: #37383b;
   position: relative;
+  font-weight: 300;
 }
 
 a:link,
@@ -237,7 +238,6 @@ p.warning {
   padding: 1rem 1.5rem;
   border: 0;
   border-radius: .25rem;
-  font-weight: 400;
   color: #333;
 }
 

--- a/themes/hanami/static/assets/css/theme.css
+++ b/themes/hanami/static/assets/css/theme.css
@@ -1,6 +1,6 @@
 /*
  * cyan: 35DDFF
- * purple: 8E43E8
+ * purple: 685D9F
  * red: FF6886
  * green: 46E895
  * yellow: FFD842
@@ -13,7 +13,7 @@ body {
 
 a:link,
 a:visited {
-  color: #8E43E8;
+  color: #685D9F;
   font-weight: 500;
 }
 
@@ -27,8 +27,7 @@ p {
 }
 
 code {
-  /* background-color: rgba(70,232,149, 0.5); */
-  background-color: rgba(255,216,66,.5);
+  background-color: rgba(245, 247, 255, 0.8);
   color: #525f7f;
   padding: 0.2em 0.1em;
   font-family: monospace;
@@ -45,12 +44,12 @@ code {
 }
 
 .headroom--not-top {
-  background-color: #8E43E8 !important;
+  background-color: #685D9F !important;
 }
 
 .section-shaped .shape-hanami
 {
-    background: linear-gradient(150deg, #8E43E8 15%, #35DDFF 70%, #46E895 94%);
+    background: linear-gradient(150deg, #685D9F 15%, #35DDFF 70%, #46E895 94%);
 }
 .section-shaped .shape-hanami :nth-child(1)
 {
@@ -85,7 +84,7 @@ code {
 
 .text-primary
 {
-    color: #8E43E8 !important;
+    color: #685D9F !important;
 }
 
 a.text-primary:hover,
@@ -135,8 +134,8 @@ a.text-primary:focus
 }
 
 .btn-outline-primary {
-  color: #8E43E8;
-  border-color: #8E43E8;
+  color: #685D9F;
+  border-color: #685D9F;
 }
 
 .btn-outline-primary:hover,
@@ -145,8 +144,8 @@ a.text-primary:focus
 .btn-outline-primary:not(:disabled):not(.disabled).active,
 .show > .btn-outline-primary.dropdown-toggle {
   color: #fff;
-  border-color: #8E43E8;
-  background-color: #8E43E8;
+  border-color: #685D9F;
+  background-color: #685D9F;
 }
 
 .badge-primary
@@ -157,7 +156,7 @@ a.text-primary:focus
 
 .badge-secondary
 {
-    color: #8E43E8;
+    color: #685D9F;
     background-color: rgba(70,232,149,.5);
 }
 .badge-secondary[href]:hover,
@@ -174,7 +173,7 @@ a.text-primary:focus
 }
 
 header.navbar {
-  background-color: #8E43E8;
+  background-color: #685D9F
 }
 
 div.highlight > pre {
@@ -200,29 +199,29 @@ main p {
 .ct-sidebar .nav > li > a:active,
 #secondary-navigation a:hover,
 #secondary-navigation a:active {
-  color: #8E43E8;
+  color: #685D9F;
 }
 
 .nav-link.active {
   font-weight: 500;
   padding-left: 1.5rem;
-  color: #8E43E8 !important;
+  color: #685D9F !important;
   background-color: transparent;
-  border-left: 1px solid #8E43E8;
+  border-left: 1px solid #685D9F;
 }
 
 .ct-page-title {
-  border-left: 2px solid #8E43E8;
+  border-left: 2px solid #685D9F;
 }
 
 .ct-sidebar .nav > .active > a,
 .ct-sidebar .nav > .active > a:hover,
 .ct-sidebar .nav > .active > a:active {
-  color: #8E43E8;
+  color: #685D9F;
 }
 
 .ct-sidebar .nav>.active>a:before {
-  background-color: #8E43E8;
+  background-color: #685D9F;
 }
 
 /* This corresponds to .alert class from original theme */
@@ -243,8 +242,7 @@ p.warning {
 }
 
 p.notice {
-  border-color: #35DDFF;
-  background-color: #35DDFF;
+  background-color: rgb(53, 221, 255, 0.3);
 }
 
 p.convention {
@@ -273,7 +271,7 @@ ul.ct-sidenav {
 
 .btn-clipboard,
 .btn-clipboard:hover {
-  background-color: #8E43E8;
+  background-color: #685D9F;
 }
 
 .text-align-right {


### PR DESCRIPTION
- Light gray background for inline code examples
- Less vibrant purple for header and buttons
- Same gray background for shell code blocks
- Reduce font size
- Make default font darker and use consistent 300 weight in both paragraphs and lists

This partly ports tweaks from #106 so see there for comparison screenshots.