### PR TITLE
Add correct content type for examples

### DIFF
--- a/content/v2.0/introduction/getting-started.md
+++ b/content/v2.0/introduction/getting-started.md
@@ -405,10 +405,10 @@ Failures:
      Failure/Error: expect(last_response.content_type).to eq("application/json; charset=utf-8")
 
        expected: "application/json; charset=utf-8"
-            got: "text/html; charset=utf-8"
+            got: "application/octet-stream; charset=utf-8"
 
        (compared using ==)
-     # ./spec/requests/books/index_spec.rb:8:in `block (2 levels) in <top (required)>'
+     # ./spec/requests/books/index_spec.rb:7:in `block (2 levels) in <top (required)>'
 ```
 
 Our response doesn't have the expected format. Let's adjust our action to return a JSON formatted response using `response.format = :json`. We'll also set the response body to what our test expects:


### PR DESCRIPTION

The change made:
<img width="961" alt="Screen Shot 2022-11-26 at 8 52 01 PM" src="https://user-images.githubusercontent.com/4859128/204115668-edc4f2d0-2df9-4acc-8844-96b9d320fb6a.png">


What I'm seeing in my console when I follow the guides and run the test:
<img width="1023" alt="Screen Shot 2022-11-26 at 8 52 36 PM" src="https://user-images.githubusercontent.com/4859128/204115678-f49f271a-7ac4-42ad-915c-8c9cf828fb65.png">
