### PR TITLE
`.empty?` method added to custom body parser

### DIFF
--- a/content/v2.0/actions/parameters.md
+++ b/content/v2.0/actions/parameters.md
@@ -330,6 +330,10 @@ class FooParser
   def parse(body)
     # manually parse body
   end
+  
+  def empty?
+    false
+  end
 end
 ```
 


### PR DESCRIPTION
I wanted to add my own JSON body parser, like Oj.
I looked and did as described in the documentation, but got an error in the RSpec tests.
I saw that the `.empty?` method is missing somewhere and added it. But I don't understand where it is being called from.

```
NoMethodError:
       undefined method `empty?' for #<OjParser:0x0000000101363df8>

                 return DEFAULT_BODY_PARSERS if parser_specs.empty?
                                                            ^^^^^^^
```

The working version of the code looks like this:
But I'm not sure if this fix is in the right place.

```ruby
# config/app.rb

config.middleware.use :body_parser, OjParser.new

# lib/oj_parser.rb

class OjParser
  def mime_types
    ['application/json']
  end

  def parse(body)
    Oj.load(body) unless body.empty?
  end

  def empty?
    false
  end
end
```
