### PR TITLE
Add a v2.0 views placeholder

### DIFF
--- a/content/v2.0/views/_index.md
+++ b/content/v2.0/views/_index.md
@@ -1,0 +1,4 @@
+---
+title: Views
+order: 90
+---

--- a/content/v2.0/views/planned_for_2_1.md
+++ b/content/v2.0/views/planned_for_2_1.md
@@ -1,8 +1,8 @@
 ---
-title: Planned for V2.1
+title: Planned for 2.1
 order: 10
 ---
 
-Hanami V2.0 does not yet have an "official" implementation of views as did V1.3. This is planned for Hanami V2.1. 
-Hanami V2.0 is well-suited for JSON APIs or manual templating with the engine of your choice through [manually setting
-`response.body`](/v2.0/actions/request-and-response/#response) in actions in the meantime.
+Hanami 2.0 does not yet include integrated view rendering. This is planned for the upcoming 2.1 release.
+
+In the meantime, Hanami 2.0 is well suited for JSON APIs or manual templating with the view engine of your choice through [manually setting `response.body`](/v2.0/actions/request-and-response/#response) in actions.

--- a/content/v2.0/views/planned_for_2_1.md
+++ b/content/v2.0/views/planned_for_2_1.md
@@ -1,0 +1,8 @@
+---
+title: Planned for V2.1
+order: 10
+---
+
+Hanami V2.0 does not yet have an "official" implementation of views as did V1.3. This is planned for Hanami V2.1. 
+Hanami V2.0 is well-suited for JSON APIs or manual templating with the engine of your choice through [manually setting
+`response.body`](/v2.0/actions/request-and-response/#response) in actions in the meantime.


### PR DESCRIPTION
In order to signpost a) when V1.3-style view support is coming to Hanami V2.x and to suggest what to do in the meantime, add a guides menu item for Views.