### PR TITLE
Fix broken links in all articles

### DIFF
--- a/content/v2.0/actions/request-and-response.md
+++ b/content/v2.0/actions/request-and-response.md
@@ -86,4 +86,4 @@ In situations where you want an action to halt, for example to return a `401 Una
 
 ### Response format
 
-The value set using `response.format` can either be a format name (`:json`) or a content type string (`"application/json"`). Consult [MIME types and formats](/v2.0/actions/mime-types-and-formats/) for more information about setting response formats.
+The value set using `response.format` can either be a format name (`:json`) or a content type string (`"application/json"`). Consult [MIME types and formats](/v2.0/actions/formats-and-mime-types/) for more information about setting response formats.

--- a/content/v2.0/app/app-config.md
+++ b/content/v2.0/app/app-config.md
@@ -68,7 +68,7 @@ Sets an array of paths (relative to the root of the app or any slice) to be excl
 
 ### `base_url`
 
-Sets the base URL for the app's web server. This is used when building URLs for named routes. Defaults to `"http://0.0.0.0:2300"`. See the [routes guide](/v2.0/routes) for more detail.
+Sets the base URL for the app's web server. This is used when building URLs for named routes. Defaults to `"http://0.0.0.0:2300"`. See the [routes guide](/v2.0/routing/overview/) for more detail.
 
 ### `middleware`
 

--- a/content/v2.0/app/providers.md
+++ b/content/v2.0/app/providers.md
@@ -3,7 +3,7 @@ title: Providers
 order: 30
 ---
 
-Providers are a way to register components with your containers, outside of the automatic registration mechanism detailed in [containers and components](/docs/application-architecture/containers).
+Providers are a way to register components with your containers, outside of the automatic registration mechanism detailed in [containers and components](/v2.0/app/container-and-components/).
 
 Providers are useful when:
 


### PR DESCRIPTION
Resolves: https://trello.com/c/HOWUg5kK/359-check-for-and-fix-broken-links

### Approach I’ve taken:

Used: https://ahrefs.com/broken-link-checker

Went through each section URL, and pasted URL to check for broken links.

*Result:* No Links Broken (returning error responses). Unfortunately, it only checked external links (starting from domain).

Then I’ve listed all URLs manually.

<img width="393" alt="image" src="https://user-images.githubusercontent.com/8088317/208264978-982bbf51-7847-4959-85f8-8255b0d73eab.png">

All Links in our articles are listed in the text below.

```markdown
guides • content/v2.0/actions/control-flow.md:
  211: See the [Routing guide](/v2.0/routing/overview/) for more information on named routes.

guides • content/v2.0/actions/cookies.md:
  6: Actions can set [cookies](https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies) on outgoing requests via the `response` object.

guides • content/v2.0/actions/http-caching.md:
   94: For more detail on action halting, see the [control flow guide](/v2.0/actions/control-flow).
  135: For more detail on action halting, see the [control flow guide](/v2.0/actions/control-flow).

guides • content/v2.0/actions/overview.md:
  36: Let's start by taking a look at action [parameters](/v2.0/actions/parameters/).

guides • content/v2.0/actions/parameters.md:
   26: - [path variables](/v2.0/routing/overview/) as specified in the route that has matched the request (e.g. `/books/:id`)
  217: Action validations use the [dry-validation](https://dry-rb.org/gems/dry-validation/) gem, which provides a powerful DSL for defining schemas.
  219: Consult the [dry-validation](https://dry-rb.org/gems/dry-validation/) and [dry-schema](https://dry-rb.org/gems/dry-schema/) gems for further documentation.

guides • content/v2.0/actions/rack-integration.md:
  8: Actions offer a high level API built on top of [Rack](https://github.com/rack/rack). To access the raw data from the Rack environment within an action, use `request.env`.

guides • content/v2.0/actions/request-and-response.md:
  25: The object inherits from [Rack::Request](https://www.rubydoc.info/gems/rack/Rack/Request), which provides a range of methods like `#path_info`, `#content_type` and `#get_header`.
  79: The `response` object inherits from [Rack::Response](https://www.rubydoc.info/gems/rack/Rack/Response).
  85: In situations where you want an action to halt, for example to return a `401 Unauthorized` response, use the action's `halt` method. To return a redirect, use `response.redirect_to("/path")`. See [Control flow](/v2.0/actions/control-flow/) for details.
  89: The value set using `response.format` can either be a format name (`:json`) or a content type string (`"application/json"`). Consult [MIME types and formats](/v2.0/actions/mime-types-and-formats/) for more information about setting response formats.

guides • content/v2.0/actions/sessions.md:
  22: For this to work, you will need to add a `session_secret` to your app settings. See [settings](/v2.0/app/settings/) for more details.

guides • content/v2.0/actions/testing.md:
  8: The examples on this page use [RSpec](http://rspec.info), the test framework installed when you generate a new Hanami app.

guides • content/v2.0/app/app-config.md:
   35: See the [environments guide](/v2.0/app/environments) for more detail.
   37: Individual slices may also be configured. See the [slices guide](/v2.0/app/slices) for more detail.
   45: Along with `inflector`, customizes your your app's string inflection rules. See the [inflector guide](/v2.0/app/inflector) for more detail.
   49: Specifies the slices to load. See the [slices guide](/v2.0/app/slices) for more detail.
   57: The root is used for locating the code to be loaded by the app. See the [autoloading guide](/v2.0/app/autoloading) and the [containers and components guide](/v2.0/app/container-and-components) for more detail.
   61: Sets the keys for the app components to be automatically imported into each slice. See the [slices guide](/v2.0/app/slices) for more detail.
   65: Sets an array of paths (relative to the root of the app or any slice) to be excluded from component auto-registration. Defaults to `["entities"]`. See the [containers and components guide](/v2.0/app/container-and-components) for more detail.
   71: Sets the base URL for the app's web server. This is used when building URLs for named routes. Defaults to `"http://0.0.0.0:2300"`. See the [routes guide](/v2.0/routes) for more detail.
  102: See the [actions guide](/v2.0/actions/overview) for more detail.

guides • content/v2.0/app/autoloading.md:
   6: Hanami uses the [Zeitwerk](https://github.com/fxn/zeitwerk) code loader to support autoloading.
  59: It's worth noting that, thanks to Hanami's [component managment system](/v2.0/app/container-and-components/), the components you write in `app/` don't commonly need to reference their collaborators using Ruby constants - they instead use the Deps mixin to access their dependencies.
  61: If you are adding a class to the `app/` directory that you want to use an autoloaded Ruby constant to reference, it's very likely that you do not want that class to be registered in your app container. To opt out of registration, use the magic comment `# auto_register: false` or one of the alternative methods discussed in "Opting out of the container" in the [container and components guide](/v2.0/app/container-and-components/).

guides • content/v2.0/app/booting.md:
   44: Assuming we have run `hanami new bookshelf` to generate a new app (see [Getting started](/v2.0/introduction/getting-started/) for a full guide to creating your first Hanami application), let's create a hello world component in `app/hello_world.rb`:
  160: You can read more about components and containers in more detail in the [container and components guide](/v2.0/app/container-and-components/). Providers are covered in the [providers guide](/v2.0/app/providers/).

guides • content/v2.0/app/code-reloading.md:
   6: Hanami offers fast code reloading in development via the [hanami-reloader](https://github.com/hanami/reloader) gem.
  31: Thanks to [Zeitwerk](/v2.0/app/autoloading/) and [lazy loading](/v2.0/app/booting/), code reloading is also very fast.

guides • content/v2.0/app/container-and-components.md:
  385: [Zeitwerk](https://github.com/fxn/zeitwerk) autoloading is in place for code you put in `lib/<app_name>`, meaning that you do not need to use a `require` statement before using it.
  419: These are your settings defined in `config/settings.rb`. See the [settings guide](/v2.0/app/settings) for more detail.
  423: The app's standard logger. See the [logger guide](/v2.0/logger/usage) for more detail.
  427: The app's inflector. See the [inflector guide](/v2.0/app/inflector) for more detail.
  431: An object providing URL helpers for your named routes. See the [routing guide](/v2.0/routing/overview/#named-routes) for more detail.

guides • content/v2.0/app/environments.md:
  100: See the [app config guide](/v2.0//app/app-config/) for information on supported config options.
  106: In production, Hanami logs to standard out by default, using a structured JSON format with a log level of `:info` rather than `:debug`, which is used in development and test. See the [logger guide](/v2.0/logger/configuration/) for more detail.

guides • content/v2.0/app/inflector.md:
   6: Hanami includes an inflector that supports the pluralization, singularization and humanization of English words, as well as other transformations. This inflector is a [Dry::Inflector](https://dry-rb.org/gems/dry-inflector) instance.
  29: A common reason for customization is to configure inflections to support desired class names and other constants. For example, the `WNBA` acronym above supports constants like `Games::WNBA` instead of `Games::Wnba`. See the [autoloading guide](/v2.0/app/autoloading/) for more detail.

guides • content/v2.0/app/providers.md:
  6: Providers are a way to register components with your containers, outside of the automatic registration mechanism detailed in [containers and components](/v2.0/app/container-and-components/).

guides • content/v2.0/app/settings.md:
   22: These "app settings" are unrelated to ["app configs"](/v2.0/app/app-config/), which configure framework behaviours. App settings are your own to define and use.
   80: These types are provided by [dry-types](https://dry-rb.org/gems/dry-types), and the `Types` module is generated for you automatically when you subclass `Hanami::Settings`.
  151: To enforce additional contraints on settings, you can use a [constraint](https://dry-rb.org/gems/dry-types/1.2/constraints/) in your constructor type.
  198: For more information on components and the Deps mixin, see the [architecture guide](/v2.0/app/container-and-components/).
  218: See the guides for [providers](/v2.0/app/providers/) and [containers](/v2.0/app/container-and-components/) for more information.
  261: Hanami uses the [dotenv gem](https://github.com/bkeepers/dotenv) to load environment variables from `.env` files.
  305: For a given `HANAMI_ENV` environment, the `.env` files are looked up in the following order, which adheres to the recommendations made by the [dotenv gem](https://github.com/bkeepers/dotenv#what-other-env-files-can-i-use):

guides • content/v2.0/app/slices.md:
  147: - `"settings"` — the app’s [settings object](/v2.0/app/settings/)
  148: - `"inflector"` — the app’s [inflector](/v2.0/app/inflector/)
  329: See the [settings guide](/v2.0/app/settings/) for more information on settings.

guides • content/v2.0/cli-commands/commands.md:
  94: See the [actions](/v2.0/actions/overview/) and [slices](/v2.0/app/slices/) guides for example usage.

guides • content/v2.0/introduction/getting-started.md:
    34: Ideally, you already have some familiarity with web applications and the [Ruby language](https://www.ruby-lang.org/en/).
    47: If you need to install or upgrade Ruby, follow the instructions on [ruby-lang.org](https://www.ruby-lang.org/en/documentation/installation/).
   146: Visit your application in the browser at [http://localhost:2300](http://localhost:2300)
   244: This `Bookshelf::Routes` class contains the configuration for our application's router. Routes in Hanami are comprised of a HTTP method, a path, and an endpoint to be invoked, which is usually a Hanami action. (See the [Routing guide](/v2.0/routing/overview/) for more information).
   320: For more details on actions, see the [Actions guide](/v2.0/actions/overview/).
   492: In Hanami, [providers](/v2.0/app/providers/) offer a mechanism for configuring and using dependencies, like databases, within your application.
   540: You can read more about Hanami's settings in the [Application guide](/v2.0/app/settings/).
   560: In development and test environments, Hanami uses the [dotenv gem](https://github.com/bkeepers/dotenv) to load environment variables from `.env` files.
   734: To access the books relation within the action, we can use Hanami's "Deps mixin". Covered in detail in the [container and components](/v2.0/app/container-and-components/) section of the Architecture guide, the Deps mixin gives each of your application's components easy access to the other components it depends on to achieve its work. We'll see this in more detail as these guides progress.
   933: You can find more details on actions and parameter validation in the [Actions guide](/v2.0/actions/overview/).
  1336: From here you might want to look in more detail at [routing](/v2.0/routing/overview/) and [actions](/v2.0/actions/overview/), or explore Hanami's [application architecture](/v2.0/app/container-and-components/), starting with its [component management](/v2.0/app/container-and-components/) and [dependency injection](/v2.0/app/container-and-components/) systems.

guides • content/v2.0/routing/overview.md:
  10: Hanami provides a fast, simple [router](https://github.com/hanami/router) for handling HTTP requests.
  30: Endpoints are usually actions within your application, but they can also be a block, a [Rack](https://github.com/rack/rack) application, or anything that responds to `#call`.
```

I've copied each URL to the browser and found a few inaccuarcies this way.