### PR TITLE
fix mdn cache control link

### DIFF
--- a/content/v2.0/actions/http-caching.md
+++ b/content/v2.0/actions/http-caching.md
@@ -46,7 +46,7 @@ The `cache_control` method accepts one or more of the following [Cache-Control d
 
 ## Expires
 
-The [Expires response header][mdn-expires] sets the date and time after which the response is considered expired. The Expires header is an older standard, and Cache-Control is preferred by modern browsers.
+The [Expires response header](mdn-expires) sets the date and time after which the response is considered expired. The Expires header is an older standard, and Cache-Control is preferred by modern browsers.
 
 You can use the `#expires` method on your action's response object to set this header along with a matching Cache-Control header.
 


### PR DESCRIPTION
For some reason, for this particular link, using brackets doesn't render the link properly