### PR TITLE
Revert "Reduce font-size for code blocks"

### DIFF
--- a/themes/hanami/static/assets/css/theme.css
+++ b/themes/hanami/static/assets/css/theme.css
@@ -30,14 +30,14 @@ p {
 p > code {
   background-color: #fafafa;
   padding: 0.25rem 0.15rem;
-  font-size: 0.8rem;
+  font-size: 0.9rem;
 }
 
 code, code[class*=language-] {
   background-color: #fafafa;
   color: #525f7f;
   font-family: monospace;
-  font-size: 0.8rem;
+  font-size: 0.9rem;
 }
 
 #search-form {


### PR DESCRIPTION
Reverts hanami/guides#163. This intersects poorly with #160, and makes all our code-formatted text way too tiny.

For example:

<img width="1330" alt="Screenshot 2023-03-06 at 9 32 40 pm" src="https://user-images.githubusercontent.com/3134/223085599-9c394c21-dc88-4cef-b7c9-05131bf54859.png">
