### PR TITLE
correct the settings example for slice to contain a constructor key

### DIFF
--- a/content/v2.0/app/slices.md
+++ b/content/v2.0/app/slices.md
@@ -293,7 +293,7 @@ You can instead elect to define settings within specific slices. To do this, cre
 
 module CDN
   class Settings < Hanami::Settings
-    setting :cdn_api_key, Types::String
+    setting :cdn_api_key, constructor: Types::String
   end
 end
 ```


### PR DESCRIPTION
I noticed a minor typo on the slices settings page where the example code didn't have the `constructor` option key. 

This PR addresses that typo