### PR TITLE
Update documentation about cookies to provide info about the same_site

### DIFF
--- a/content/v1.3/actions/cookies.md
+++ b/content/v1.3/actions/cookies.md
@@ -35,6 +35,7 @@ With that configuration we can specify options that will be set for all cookies 
   * `:max_age` - `Integer` (`nil` by default), cookie duration expressed in seconds
   * `:secure` - `Boolean` (`true` by default if using SSL), restrict cookies to secure connections
   * `:httponly` - `Boolean` (`true` by default), restrict JavaScript access to cookies
+  * `:same_site` - `String` (`nil` by default), to control when cookies are sent even on different websites. Possible values are: nil, None, Lax, Strict
 
 ## Usage
 


### PR DESCRIPTION
I had some troubles finding the right syntax, so I think it would be good to add it to the doc

Supported by Rack::Utils, see:
https://github.com/rack/rack/blob/8f5c885f7e0427b489174a55e6d88463173f22d2/lib/rack/utils.rb#L292C23-L292C32