### PR TITLE
Add helpers section and string escaping guide

### DIFF
--- a/content/v2.1/helpers/_index.md
+++ b/content/v2.1/helpers/_index.md
@@ -1,0 +1,4 @@
+---
+title: Helpers
+order: 130
+---

--- a/content/v2.1/helpers/overview.md
+++ b/content/v2.1/helpers/overview.md
@@ -1,0 +1,10 @@
+---
+title: Overview
+order: 10
+---
+
+Hanami provides a range of standard helpers for you to use in your views.
+
+You can read more about where helpers fit within your views in the [view helpers guide](/v2.1/views/helpers/).
+
+To learn more about Hanami's standard helpers, read the sections within this guide.

--- a/content/v2.1/helpers/string-escaping.md
+++ b/content/v2.1/helpers/string-escaping.md
@@ -1,0 +1,57 @@
+---
+title: String escaping
+order: 20
+---
+
+## HTML escaping
+
+`escape_html` (also aliased as `h`) returns an escaped string that is [safe to include in HTML templates](/v2.1/views/templates/). Use this helper when including any untrusted user input in HTML content, particularly within other helpers that mix untrusted input among HTML tags.
+
+This helper marks the escaped string marked as HTML-safe, ensuring it will not be escaped again. If the given string is already marked as HTML-safe, then it will be returned without escaping.
+
+```ruby
+escape_html("Safe content")
+# => "Safe content"
+
+escape_html("<script>alert('xss')</script>")
+# => "&lt;script&gt;alert(&#39;xss&#39;)&lt;/script&gt;"
+
+escape_html(raw("<p>Not escaped</p>"))
+# => "<p>Not escaped</p>"
+```
+
+## Bypassing HTML escaping
+
+`raw` returns the given string marked as HTML-safe (regardless of its content), meaning it will not be escaped when included in your view's HTML.
+
+**This is NOT recommended if the string is coming from untrusted user input. Use at your own peril.**
+
+```ruby
+raw(user.name)
+# => "Little Bobby <alert>Tables</alert>"
+
+raw(user.name).html_safe?
+# => true
+```
+
+## URL sanitizing
+
+`sanitize_url` returns a the given URL string if it has one of the permitted URL schemes. For URLs with non-permitted schemes, this returns an empty string.
+
+Use this method when including URLs from untrusted user input in your view content.
+
+The default permitted schemes are:
+- `http`
+- `https`
+- `mailto`
+
+```ruby
+sanitize_url("https://hanamirb.org")
+# => "http://hanamirb.org"
+
+sanitize_url("javascript:alert('xss')")
+# => ""
+
+sanitize_url("gemini://gemini.circumlunar.space/", %w[http https gemini])
+# => "gemini://gemini.circumlunar.space/"
+```


### PR DESCRIPTION
Begin the "Helpers" section of the guides. Add an _Overview_ page and a _String escaping_ page.

The helpers overview page is kind of a stub, since it's only job really is to be a landing page that (a) can redirect the reader to the appropriate sub-section of the views guide to see how helpers _fit_ within views, or (b) encourage them to keep reading to learn more about specific helpers. Open to ideas about making this better, but I'm fine just to leave this as it is, too.

Add a first helper page while we're here: _String escaping_. This was called _Markup escaping_ in the 1.3 guides, but that felt a little awkward to me, so I've gone with the more general "String" term here. Happy to adjust based on feedback.

Resolves #198
Resolves #190