### PR TITLE
Hanami v2.1: Change ERB code snippets to sql

### DIFF
--- a/content/v2.1/cli-commands/commands.md
+++ b/content/v2.1/cli-commands/commands.md
@@ -1,6 +1,6 @@
 ---
 title: Commands
-order: 50
+order: 10
 ---
 
 Hanami provides a command line interface with helpful commands for generating a new application, starting a console, starting a development server, displaying routes and more.
@@ -17,163 +17,22 @@ Commands:
   hanami version         # Hanami version
 ```
 
-### hanami new
+## App commands
 
-Generates a Hanami application with the given APP name, in a new directory from the current location.
-
-```shell
-$ hanami new bookshelf # generates a new Bookshelf application in ./bookshelf
-$ hanami new my_app # generates a new MyApp application in ./my_app
-```
-
-
-### hanami version
-
-Displays the Hanami version of the currently installed gem.
-
-```shell
-$ hanami version
-v2.0.0
-```
-
-
-## Project commands
-
-When executed from within a hanami project, hanami offers a different set of commands.
+When executed from within a Hanami app, hanami offers a different set of commands.
 
 These commands can be listed using the `--help` flag.
 
 ```shell
 $ bundle exec hanami --help
-
 Commands:
+  hanami assets [SUBCOMMAND]
   hanami console                              # Start app console (REPL)
+  hanami dev                                  # Start the application in development mode
   hanami generate [SUBCOMMAND]
+  hanami install                              # Install Hanami third-party plugins
   hanami middleware                           # Print app Rack middleware stack
   hanami routes                               # Print app routes
   hanami server                               # Start Hanami app server
   hanami version                              # Print Hanami app version
-```
-
-## hanami console
-
-Starts the Hanami console.
-
-```shell
-$ bundle exec hanami console
-
-bookshelf[development]>
-```
-
-This command accepts an `engine` argument that can start the console using IRB or Pry.
-
-```shell
-$ bundle exec hanami console --engine=irb # (the default)
-$ bundle exec hanami console --engine=pry
-```
-
-## hanami generate
-
-Hanami 2.0 provides two generators, one for actions and one for slices.
-
-```shell
-$ bundle exec hanami generate --help
-
-Commands:
-  hanami generate action NAME
-  hanami generate slice NAME
-```
-
-These can be invoked as follows:
-
-```shell
-$ hanami generate action books.show
-$ hanami generate slice api
-```
-
-See the [actions](/v2.1/actions/overview/) and [slices](/v2.1/app/slices/) guides for example usage.
-
-## hanami middleware
-
-Displays the Rack middleware stack as currently configured.
-
-```shell
-$ bundle exec hanami middleware
-
-/    Dry::Monitor::Rack::Middleware (instance)
-/    Rack::Session::Cookie
-/    Hanami::Middleware::BodyParser
-```
-
-This command accepts a `--with-arguments` option that will include initialization arguments:
-
-```shell
-$ bundle exec hanami middleware --with-arguments
-
-/    Dry::Monitor::Rack::Middleware (instance) args: []
-/    Rack::Session::Cookie args: [{:key=>"my_app.session", :secret=>"secret", :expire_after=>31536000}]
-/    Hanami::Middleware::BodyParser args: [:json]
-```
-
-## hanami routes
-
-Displays your application's routes.
-
-```shell
-$ bundle exec hanami routes
-
-GET     /                             home.index                    as :root
-GET     /books                        books.index
-GET     /books/:id                    books.show
-POST    /books                        books.create
-```
-
-By default, routes are displayed in "human friendly" format. Routes can be inspected in csv format via the format option:
-
-```shell
-$ bundle exec hanami routes --format=csv
-
-METHOD,PATH,TO,AS,CONSTRAINTS
-GET,/,home.index,:root,""
-GET,/books,books.index,"",""
-GET,/books/:id,books.show,"",""
-POST,/books,books.create,"",""
-```
-
-## hanami server
-
-Launches hanami's development server for developing against your application locally.
-
-```shell
-$ bundle exec hanami server
-
-14:33:28 - INFO - Using Guardfile at bookshelf/Guardfile.
-14:33:28 - INFO - Puma starting on port 2300 in development environment.
-14:33:28 - INFO - Guard is now watching at 'bookshelf'
-[43884] Puma starting in cluster mode...
-[43884] * Puma version: 6.0.0 (ruby 3.1.0-p0) ("Sunflower")
-[43884] *  Min threads: 5
-[43884] *  Max threads: 5
-[43884] *  Environment: development
-[43884] *   Master PID: 43884
-[43884] *      Workers: 2
-[43884] *     Restarts: (✔) hot (✖) phased
-[43884] * Preloading application
-[43884] * Listening on http://0.0.0.0:2300
-[43884] Use Ctrl-C to stop
-```
-
-This server is for local development only. In production, use the following to start your application serving web requests with Puma:
-
-```shell
-$ bundle exec puma -C config/puma.rb
-```
-
-## hanami version
-
-Prints the version of the installed hanami gem.
-
-```shell
-$ bundle exec hanami version
-v2.0.0
 ```

--- a/content/v2.1/cli-commands/console.md
+++ b/content/v2.1/cli-commands/console.md
@@ -1,0 +1,21 @@
+---
+title: Console
+order: 40
+---
+
+## hanami console
+
+Starts the Hanami console (REPL).
+
+```shell
+$ bundle exec hanami console
+
+bookshelf[development]>
+```
+
+This command accepts an `engine` argument that can start the console using IRB or Pry.
+
+```shell
+$ bundle exec hanami console --engine=irb # (the default)
+$ bundle exec hanami console --engine=pry
+```

--- a/content/v2.1/cli-commands/dev.md
+++ b/content/v2.1/cli-commands/dev.md
@@ -1,0 +1,36 @@
+---
+title: Dev
+order: 60
+---
+
+## hanami dev
+
+Starts Hanami application in development mode.
+
+```shell
+$ bundle exec hanami dev
+```
+
+### Procfile.dev
+
+Starting from Hanami 2.1, new apps have a `Procfile.dev`, where developers can manage the processes that should be managed by `hanami dev`.
+
+Those are the default contents:
+
+```shell
+web: bundle exec hanami server
+assets: bundle exec hanami assets watch
+```
+
+### bin/dev
+
+By default Hanami 2.1+, installs the `foreman` Ruby gem to run the `Procfile.dev`.
+
+In case you want use a different process manager, edit application's `bin/dev`.
+
+Example that uses [shoreman](https://github.com/chrismytton/shoreman), instead of `foreman`:
+
+```shell
+#!/usr/bin/env sh
+shoreman Procfile.dev
+```

--- a/content/v2.1/cli-commands/generate.md
+++ b/content/v2.1/cli-commands/generate.md
@@ -1,0 +1,73 @@
+---
+title: Generate
+order: 90
+---
+
+## hanami generate
+
+Hanami 2.1 provides a few generators:
+
+```shell
+$ bundle exec hanami generate --help
+Commands:
+  hanami generate action NAME
+  hanami generate part NAME
+  hanami generate slice NAME
+  hanami generate view NAME
+```
+
+### hanami generate action
+
+Generates an [action](/v2.1/actions/overview):
+
+```shell
+$ bundle exec hanami generate action books.show
+```
+
+Use the `--help` option to access all accepted options:
+
+```shell
+$ bundle exec hanami generate action --help
+```
+
+### hanami generate part
+
+Generates a view [part](/v2.1/views/parts/):
+
+```shell
+$ bundle exec hanami generate part book
+```
+
+Use the `--help` option to access all accepted options:
+
+```shell
+$ bundle exec hanami generate part --help
+```
+
+### hanami generate slice
+
+Generates a [slice](/v2.1/app/slices/):
+
+```shell
+$ bundle exec hanami generate slice admin
+```
+
+Use the `--help` option to access all accepted options:
+
+```shell
+$ bundle exec hanami generate slice --help
+```
+
+### hanami generate view
+
+Generates a [view](/v2.1/views/overview/):
+
+```shell
+$ bundle exec hanami generate view books.create
+```
+
+Use the `--help` option to access all accepted options:
+
+```shell
+$ bundle exec hanami generate view --help
+```

--- a/content/v2.1/cli-commands/install.md
+++ b/content/v2.1/cli-commands/install.md
@@ -1,0 +1,16 @@
+---
+title: Install
+order: 30
+---
+
+## hanami install
+
+This command installs third-party dependencies (Ruby gems, NPM packages) and setups additional Hanami gems that provide code reloading, rspec, integrations.
+
+<p class="notice">
+  This command is executed automatically by <code>hanami new</code>. In case you'll run into third-party dependency problems, execute it.
+<p>
+
+```shell
+$ bundle exec hanami install
+```

--- a/content/v2.1/cli-commands/middleware.md
+++ b/content/v2.1/cli-commands/middleware.md
@@ -1,0 +1,26 @@
+---
+title: Middleware
+order: 80
+---
+
+## hanami middleware
+
+Displays the Rack middleware stack as currently configured.
+
+```shell
+$ bundle exec hanami middleware
+
+/    Dry::Monitor::Rack::Middleware (instance)
+/    Rack::Session::Cookie
+/    Hanami::Middleware::BodyParser
+```
+
+This command accepts a `--with-arguments` option that will include initialization arguments:
+
+```shell
+$ bundle exec hanami middleware --with-arguments
+
+/    Dry::Monitor::Rack::Middleware (instance) args: []
+/    Rack::Session::Cookie args: [{:key=>"my_app.session", :secret=>"secret", :expire_after=>31536000}]
+/    Hanami::Middleware::BodyParser args: [:json]
+```

--- a/content/v2.1/cli-commands/new.md
+++ b/content/v2.1/cli-commands/new.md
@@ -1,0 +1,23 @@
+---
+title: New
+order: 20
+---
+
+## hanami new
+
+Generates a Hanami application with the given APP name, in a new directory from the current location.
+
+```shell
+$ hanami new bookshelf # generates a new Bookshelf application in ./bookshelf
+$ hanami new my_app # generates a new MyApp application in ./my_app
+```
+
+On the application generation, Hanami performs gem bundling, NPM bundling, and general application setup.
+
+### Using Hanami HEAD
+
+In case you're interested to debug a Hanami issue, you can generate an application that uses the HEAD version of Hanami, directly from the `main` branches of the GitHub repositories.
+
+```shell
+$ hanami new bookshelf --head
+```

--- a/content/v2.1/cli-commands/routes.md
+++ b/content/v2.1/cli-commands/routes.md
@@ -1,0 +1,29 @@
+---
+title: Routes
+order: 70
+---
+
+## hanami routes
+
+Displays your application's routes.
+
+```shell
+$ bundle exec hanami routes
+
+GET     /                             home.index                    as :root
+GET     /books                        books.index
+GET     /books/:id                    books.show
+POST    /books                        books.create
+```
+
+By default, routes are displayed in "human friendly" format. Routes can be inspected in csv format via the format option:
+
+```shell
+$ bundle exec hanami routes --format=csv
+
+METHOD,PATH,TO,AS,CONSTRAINTS
+GET,/,home.index,:root,""
+GET,/books,books.index,"",""
+GET,/books/:id,books.show,"",""
+POST,/books,books.create,"",""
+```

--- a/content/v2.1/cli-commands/server.md
+++ b/content/v2.1/cli-commands/server.md
@@ -1,0 +1,53 @@
+---
+title: Server
+order: 50
+---
+
+## hanami server
+
+Launches Hanami's development server for developing against your application locally.
+
+```shell
+$ bundle exec hanami server
+
+12:30:50 - INFO - Using Guardfile at bookshelf/Guardfile.
+12:30:50 - INFO - Puma starting on port 2300 in development environment.
+12:30:50 - INFO - Guard is now watching at 'bookshelf'
+Puma starting in single mode...
+* Puma version: 6.4.0 (ruby 3.2.2-p53) ("The Eagle of Durango")
+*  Min threads: 5
+*  Max threads: 5
+*  Environment: development
+*          PID: 93401
+* Listening on http://0.0.0.0:2300
+* Starting control server on http://127.0.0.1:9293
+* Starting control server on http://[::1]:9293
+Use Ctrl-C to stop
+```
+
+**This server is for local development only**. In production, use the following to start your application serving web requests with Puma:
+
+```shell
+$ bundle exec puma -C config/puma.rb
+```
+
+### Code Reloading
+
+Hanami offers a useful development feature: code reloading.
+
+When the application code changes, the application is reloaded, so for new incoming HTTP requests, the app works with the most recent version of the code.
+It's convenient feature to avoid developers to stop and start the web server for each code change.
+
+This feature is provided by the `hanami-reloader` Ruby gem.
+
+In case you want to disable permanently this feature, remove the gem from the app's `Gemfile`.
+
+In case you want to disable temporarly, start the server with the `--no-code-reloading` CLI option.
+
+```shell
+$ bundle exec hanami server --no-code-reloading
+```
+
+<p class="notice">
+  Disabling code reloading is essential to debug application code with debuggin Ruby gems like <code>byebug</code>, <code>debug</code>, or <code>pry</code>.
+</p>

--- a/content/v2.1/cli-commands/version.md
+++ b/content/v2.1/cli-commands/version.md
@@ -1,0 +1,13 @@
+---
+title: Version
+order: 100
+---
+
+## hanami version
+
+Prints the version of the Hanami version used by the application:
+
+```shell
+$ bundle exec hanami version
+v2.1.0
+```

--- a/content/v2.1/helpers/overview.md
+++ b/content/v2.1/helpers/overview.md
@@ -3,7 +3,7 @@ title: Overview
 order: 10
 ---
 
-Hanami provides a range of standard helpers for you to use in your views.
+Hanami provides a range of standard helpers for you to use in your [views](/v2.1/views/overview/).
 
 You can read more about where helpers fit within your views in the [view helpers guide](/v2.1/views/helpers/).
 

--- a/content/v2.1/helpers/tag_helper.md
+++ b/content/v2.1/helpers/tag_helper.md
@@ -9,7 +9,7 @@ This helper makes accessible all the HTML-related tags.
 
 Here is how you can use it **in templates**:
 
-```ruby
+```sql
 <%= tag.div(id: "el") do %>
   <p>Template content can be mixed in.</p>
   <%= tag.p("Also nested tag builders.") %>
@@ -65,7 +65,7 @@ end
 
 Then in the template you can just access the part:
 
-```ruby
+```sql
 # app/templates/books/show.html.erb
 
 <%= book.formatted_title %>
@@ -167,7 +167,7 @@ The URL becomes first argument in case the block is passed.
 link_to("/") { "Home" }
 # => <a href="/">Home</a>
 
-link_to("Home", "/", class: "button") %>
+link_to("Home", "/", class: "button")
 # => <a href="/" class="button">Home</a>
 ```
 

--- a/content/v2.1/helpers/tag_helper.md
+++ b/content/v2.1/helpers/tag_helper.md
@@ -1,0 +1,204 @@
+---
+title: Tag Helper
+order: 30
+---
+
+This helper makes accessible all the HTML-related tags.
+
+## Usage
+
+Here is how you can use it **in templates**:
+
+```ruby
+<%= tag.div(id: "el") do %>
+  <p>Template content can be mixed in.</p>
+  <%= tag.p("Also nested tag builders.") %>
+<% end %>
+```
+
+This will render:
+
+```html
+<div id="el">
+  <p>Template content can be mixed in.</p>
+  <p>Also nested tag builders.</p>
+</div>
+```
+
+[In parts](/v2.1/views/parts), you can access your helpers via the `helpers` object.
+
+Given you have a view exposure defined:
+
+```ruby
+# app/views/books/show.rb
+
+module Bookshelf
+  module Views
+    module Books
+      class Show < Bookshelf::View
+        expose :book do
+          Book.new(title: "Hanami")
+        end
+      end
+    end
+  end
+end
+```
+
+Then you can have the part with the helper used.
+
+```ruby
+# app/views/parts/book.rb
+
+module Bookshelf
+  module Views
+    module Parts
+      module Book
+        def formatted_title
+          helpers.tag.h1(value.title)
+        end
+      end
+    end
+  end
+end
+```
+
+Then in the template you can just access the part:
+
+```ruby
+# app/templates/books/show.html.erb
+
+<%= book.formatted_title %>
+```
+
+## Features
+
+Here are lists of features with the corresponding examples:
+
+**Auto-closing tags according to HTML5 spec**
+
+```ruby
+tag.div # => <div></div>
+```
+
+**Content string as first argument**
+
+```ruby
+tag.img # => <img>
+tag.div("First argument is content")        # => <div>First argument is content</div>
+```
+
+**Accepts content as block returning a string**
+
+```ruby
+tag.div { "Content in the block" }     # => <div>Content in the block</div>
+```
+
+**Allows for nesting tags via argument or block**
+
+```ruby
+tag.div(tag.p("Nested tag builder")) # => <div><p>Nested tag builder</p></div>
+
+tag.div do
+  tag.p("Also nested tag builders.")
+end
+```
+
+**It builds attributes from given hash**
+
+```ruby
+tag.div("With Additional attributes", class: ["a", "b"]) # => <div class="a b">With additional attributes</div>
+```
+
+**Builds nested HTML attributes attributes from given hash**
+
+```ruby
+tag.div(id: "el", data: {x: "y"}) # => <div id="el" data-x="y"></div>
+tag.div(id: "el", aria: {x: "y"}) # => <div id="el" aria-x="y"></div>
+```
+
+**Allows for dynamic attributes visibility control**
+
+```ruby
+tag.div("Dynamic attributes", class: {"a": true, "b": false}) # => <div class="a">Dynamic Attributes</div>
+```
+
+**Supports custom tags**
+
+```ruby
+tag.custom_tag("hello") # => <custom-tag>hello</custom-tag>
+```
+
+
+## Escaping HTML input
+
+The tag contents are automatically escaped for security reasons:
+
+```ruby
+tag.p("<script>alert()</script>")         # => <p>&lt;script&gt;alert()&lt;/script&gt;</p>
+tag.p(class: "<script>alert()</script>")  # => <p class="&lt;script&gt;alert()&lt;/script&gt;"></p>
+```
+
+To bypass it use `html_safe` on the given content
+
+```ruby
+tag.p("<em>safe content</em>".html_safe)  # => <p><em>safe content</em></p>
+```
+
+## link_to helper
+
+For anchors, we have a dedicated wrapper `link_to` on `tag.a`, that shares all the features with the [tag helpers](/v2.1/helpers/overview#tag-helper).
+
+Returns an anchor tag for the given contents and URL.
+### Usage
+
+The difference is, that you may pass `url` as a second argument, right after the content.
+
+```ruby
+link_to(content, url, **attributes)
+
+link_to("Home", "/")
+# => <a href="/">Home</a>
+```
+
+The URL becomes first argument in case the block is passed.
+
+```ruby
+link_to("/") { "Home" }
+# => <a href="/">Home</a>
+
+link_to("Home", "/", class: "button") %>
+# => <a href="/" class="button">Home</a>
+```
+
+### Automatic escaping
+
+The tag's contents are automatically escaped (unless marked as HTML safe).
+
+```ruby
+link_to("<script>alert('xss')</script>", "/")
+# => <a href="/">&lt;script&gt;alert(&#39;xss&#39;)&lt;/script&gt;</a>
+
+link_to("/") { "<script>alert('xss')</script>" }
+# => <a href="/">&lt;script&gt;alert(&#39;xss&#39;)&lt;/script&gt;</a>
+```
+
+## token_list helper
+
+This helper returns a string of space-separated tokens from a range of given arguments. It's intended for building an HTML tag attribute value, such as a list of class names
+
+### Usage
+
+```ruby
+token_list("foo", "bar")
+# => "foo bar"
+#
+token_list("foo", "foo bar")
+# => "foo bar"
+#
+token_list({ foo: true, bar: false })
+# => "foo"
+#
+token_list(nil, false, 123, "", "foo", { bar: true })
+# => "123 foo bar"
+```

--- a/content/v2.1/introduction/building-a-web-app.md
+++ b/content/v2.1/introduction/building-a-web-app.md
@@ -726,8 +726,6 @@ module Bookshelf
   module Actions
     module Books
       class Index < Bookshelf::Action
-        include Deps["persistence.rom"]
-
         def handle(request, response)
           response.render(
             view,

--- a/content/v2.1/introduction/building-a-web-app.md
+++ b/content/v2.1/introduction/building-a-web-app.md
@@ -37,7 +37,6 @@ You should see:
 Root
   is not found
 
-Finished in 0.01986 seconds (files took 0.70103 seconds to load)
 1 example, 0 failures
 ```
 
@@ -70,7 +69,6 @@ Failures:
      Failure/Error: expect(last_response.body).to include "Welcome to Bookshelf"
        expected "Not Found" to include "Welcome to Bookshelf"
 
-Finished in 0.0153 seconds (files took 0.19682 seconds to load)
 1 example, 1 failure
 ```
 
@@ -231,8 +229,6 @@ This new test should also pass:
 
 ```shell
 $ bundle exec rspec spec/features/home_spec.rb
-
-Randomized with seed 17230
 
 Home
   visiting the home page shows a welcome message
@@ -1136,8 +1132,6 @@ At this point, running the test hints at our next step:
 ```shell
 $ bundle exec rspec spec/features/books/create_spec.rb
 
-Randomized with seed 61697
-
 Creating books
   creates a book when given valid attributes (FAILED - 1)
   shows errors and does not create the book when given invalid attributes (FAILED - 2)
@@ -1270,7 +1264,6 @@ Creating books
   shows errors and does not create the book when given invalid attributes
   creates a book when given valid attributes
 
-Finished in 0.12918 seconds (files took 0.53517 seconds to load)
 2 examples, 0 failures
 ```
 

--- a/content/v2.1/introduction/building-a-web-app.md
+++ b/content/v2.1/introduction/building-a-web-app.md
@@ -456,6 +456,10 @@ DATABASE_URL=postgres://postgres:postgres@localhost:5432/bookshelf_test
   You might need to adjust these connection strings based on your local postgres configuration.
 </p>
 
+<p class="notice">
+  See <a href="/v2.1/app/settings/#using-dotenv-to-manage-environment-variables">Using dotenv to manage environment variables</a> for recommendations on handling these files.
+</p>
+
 To confirm that the `database_url` setting is working as expected, you can run `bundle exec hanami console` to start a console, then call the `database_url` method on your app's settings object.
 
 ```shell
@@ -1189,6 +1193,10 @@ And add a dummy secret to your `.env`:
 ```
 SESSION_SECRET=__local_development_secret_only__
 ```
+
+<p class="notice">
+  See <a href="/v2.1/app/settings/#using-dotenv-to-manage-environment-variables">Using dotenv to manage environment variables</a> for recommendations on handling these files.
+</p>
 
 Next we can update the app layout to show the flash messages, if there are any:
 

--- a/content/v2.1/introduction/building-a-web-app.md
+++ b/content/v2.1/introduction/building-a-web-app.md
@@ -33,7 +33,7 @@ $ bundle exec rspec spec/requests/root_spec.rb
 
 You should see:
 
-```
+```shell
 Root
   is not found
 

--- a/content/v2.1/introduction/building-an-api.md
+++ b/content/v2.1/introduction/building-an-api.md
@@ -309,12 +309,12 @@ Of course, returning a static list of books is not particularly useful.
 Let's address this by retrieving books from a database.
 
 <p class="notice">
-  Integrated support for persistence based on <a href="https://rom-rb.org/">rom-rb</a> is coming in Hanami's 2.1 release. For now, we can bring our own simple rom-rb configuration to allow us to store books in a database.
+  Integrated support for persistence based on <a href="https://rom-rb.org/">ROM</a> is coming in Hanami's 2.1 release. For now, we can bring our own simple ROM configuration to allow us to store books in a database.
 </p>
 
-### Adding persistence using rom-rb
+### Adding persistence using ROM
 
-Let's add just enough rom-rb to get persistence working using Postgres.
+Let's add just enough ROM to get persistence working using Postgres.
 
 First, add these gems to the Gemfile and run `bundle install`:
 
@@ -478,7 +478,7 @@ And then append the following line to `spec/spec_helper.rb`:
 require_relative "support/database_cleaner"
 ```
 
-Finally, enable rom-rb's rake tasks for database migrations by appending the following to the `Rakefile`:
+Finally, enable ROM's rake tasks for database migrations by appending the following to the `Rakefile`:
 
 ```ruby
 # Rakefile
@@ -543,7 +543,7 @@ $ bundle exec rake db:migrate
 $ HANAMI_ENV=test bundle exec rake db:migrate
 ```
 
-Lastly, let's add a rom-rb relation to allow our app to interact with our books table. Create the following file at `lib/bookshelf/persistence/relations/books.rb`:
+Lastly, let's add a ROM relation to allow our app to interact with our books table. Create the following file at `lib/bookshelf/persistence/relations/books.rb`:
 
 ```ruby
 # lib/bookshelf/persistence/relations/books.rb
@@ -592,7 +592,7 @@ To get this spec to pass, we'll need to update our books index action to return 
 
 To access the books relation within the action, we can use Hanami's "Deps mixin". Covered in detail in the [container and components](/v2.1/app/container-and-components/) section of the Architecture guide, the Deps mixin gives each of your app's components easy access to the other components it depends on to achieve its work. We'll see this in more detail as these guides progress.
 
-For now however, it's enough to know that we can use `include Deps["persistence.rom"]` to make rom-rb available via a `rom` method within our action. The books relation is then available via `rom.relations[:books]`.
+For now however, it's enough to know that we can use `include Deps["persistence.rom"]` to make ROM available via a `rom` method within our action. The books relation is then available via `rom.relations[:books]`.
 
 To satisfy our spec, we need to meet a few requirements. Firstly, we want to render each book's _title_ and _author_, but not its _id_. Secondly we want to return books alphabetically by title. We can achieve these requirements using the `select` and `order` methods offered by the books relation:
 
@@ -636,7 +636,7 @@ Finished in 0.05765 seconds (files took 1.36 seconds to load)
 
 ## Parameter validation
 
-Of course, returning _every_ book in the database when a visitor makes a request to `/books` is not going to be a good strategy for very long. Luckily rom-rb relations offer pagination support. Let's add pagination with a default page size of 5:
+Of course, returning _every_ book in the database when a visitor makes a request to `/books` is not going to be a good strategy for very long. Luckily ROM relations offer pagination support. Let's add pagination with a default page size of 5:
 
 ```ruby
 # lib/bookshelf/persistence/relations/books.rb
@@ -929,7 +929,7 @@ module Bookshelf
 end
 ```
 
-In addition to the `#one` method, which will return `nil` if there's no book with the requisite id, rom-rb relations also provide a `#one!` method, which instead raises a `ROM::TupleCountMismatchError` exception when no record is found.
+In addition to the `#one` method, which will return `nil` if there's no book with the requisite id, ROM relations also provide a `#one!` method, which instead raises a `ROM::TupleCountMismatchError` exception when no record is found.
 
 We can use this to handle 404s via Hanami's action exception handling: `config.handle_exception`. This action configuration takes the name of a method to invoke when a particular exception occurs.
 

--- a/content/v2.1/introduction/building-an-api.md
+++ b/content/v2.1/introduction/building-an-api.md
@@ -426,6 +426,10 @@ DATABASE_URL=postgres://postgres:postgres@localhost:5432/bookshelf_test
   You might need to adjust these connection strings based on your local postgres configuration.
 </p>
 
+<p class="notice">
+  See <a href="/v2.1/app/settings/#using-dotenv-to-manage-environment-variables">Using dotenv to manage environment variables</a> for recommendations on handling these files.
+</p>
+
 To confirm that the `database_url` setting is working as expected, you can run `bundle exec hanami console` to start a console, then call the `database_url` method on your app's settings object.
 
 ```shell

--- a/content/v2.1/views/context.md
+++ b/content/v2.1/views/context.md
@@ -9,7 +9,7 @@ These facilities are exposed via methods on the context object. For example, the
 
 In templates and scopes, you can call these methods implicitly, without an explicit receiver:
 
-```erb
+```sql
 <%= inflector.pluralize("koala") %>
 ```
 

--- a/content/v2.1/views/helpers.md
+++ b/content/v2.1/views/helpers.md
@@ -21,7 +21,7 @@ format_number(1234) # => "1,234"
 
 You can call helpers directly by their method names in your templates:
 
-```erb
+```sql
 <p><%= format_number(1234) %></p>
 ```
 

--- a/content/v2.1/views/parts.md
+++ b/content/v2.1/views/parts.md
@@ -86,7 +86,7 @@ When using a part, you can call any methods that belond to the decorated value, 
 
 For example, from a template:
 
-```erb
+```sql
 <!-- All the book methods are callable directly on the part -->
 <p><%= book.title %></p>
 ```
@@ -116,7 +116,7 @@ end
 
 When output directly to a template, a part will use its value's `#to_s` (which you can also override in your own part classes):
 
-```erb
+```sql
 <p><%= book %></p>
 ```
 
@@ -132,7 +132,7 @@ class Book < Bookshelf::Views::Part
 end
 ```
 
-```erb
+```sql
 <%= book.info_box %>
 ```
 
@@ -140,7 +140,7 @@ This will render a `books/_info_box` partial template with the part available as
 
 You can also render such partials explicitly within templates:
 
-```erb
+```sql
 <%= book.render("books/info_box") %>
 ```
 

--- a/content/v2.1/views/scopes.md
+++ b/content/v2.1/views/scopes.md
@@ -87,7 +87,7 @@ Within a scope class, or any partial rendered via that scope, you can access the
 
 For example, from a template:
 
-```erb
+```sql
 <!-- Given an `item:` local passed to the scope -->
 <%= item.title %>
 ```

--- a/content/v2.1/views/templates-and-partials.md
+++ b/content/v2.1/views/templates-and-partials.md
@@ -43,7 +43,7 @@ Each view's template is rendered within a layout. Layouts are kept within the `t
 
 Every layout should `yield` at the appropriate location to include the content from the template. For example:
 
-```erb
+```sql
 # app/templates/layouts/app.html.erb
 
 <html>
@@ -71,7 +71,7 @@ end
 
 You may choose to skip the auto-escaping of non-HTML safe strings by using particular template tags. In ERB:
 
-```erb
+```sql
 <%== "<p>Non-safe strings will not be auto-escaped</p>" %>
 ```
 
@@ -92,7 +92,7 @@ You may choose to provide custom scopes for templates and partials. To learn mor
 
 You can render a partial from your template using the `render` method:
 
-```erb
+```sql
 <%= render "path/to/my_partial" %>
 ```
 
@@ -100,7 +100,7 @@ Partials are looked up within the templates directory, with the partial's file n
 
 You can provide explicit locals to a partial via keyword arguments:
 
-```erb
+```sql
 <%= render "path/to/my_partial", my_locals: "go here" %>
 ```
 


### PR DESCRIPTION
We do not have a syntax highlighting for ERB snippets.

<img width="612" alt="image" src="https://github.com/hanami/guides/assets/8088317/87b49903-d184-4d5a-a48d-57f3d1d3fb18">

After:

<img width="724" alt="image" src="https://github.com/hanami/guides/assets/8088317/0a832052-50cd-48d2-a5f9-fc26c347b8d5">


Until we add the highlighting engine for ERB snippets, we should use `sql`

Reasoning:
1. We already do it in most of the erb snippets
2. We don't have too much SQL code in our guides, so replacing that will be quite quick in the future
3. Syntax highlighting works a bit better, correctly recognizing at least opening and closing tags for both HTML and Ruby parts of the code.