### PR TITLE
Fixed broken link to code-reloading guide by setting up an alias

### DIFF
--- a/content/v2.1/app/code-reloading.md
+++ b/content/v2.1/app/code-reloading.md
@@ -1,6 +1,8 @@
 ---
 title: Code reloading
 order: 90
+aliases:
+  - "/app/code-reloading"
 ---
 
 Hanami offers fast code reloading in development via the [hanami-reloader](https://github.com/hanami/reloader) gem.


### PR DESCRIPTION

I noticed that the link provided in the [v2.1.0 upgrade notes](https://guides.hanamirb.org/v2.1/upgrade-notes/v2.1.0/) pointing to the code-reloading guide (https://guides.hanamirb.org/app/code-reloading/) results in a 404 error. To resolve this issue and improve the user experience, I've set up an alias that redirects to the correct page. This ensures that users can seamlessly access the information on code-reloading without encountering broken links.

Please review the changes and let me know if any further adjustments are needed.