### PR TITLE
Fix typo of using part instead of scope

### DIFF
--- a/content/v2.1/views/scopes.md
+++ b/content/v2.1/views/scopes.md
@@ -26,7 +26,7 @@ module Bookshelf
 end
 ```
 
-It's recommended to define a base part for the other parts in the app or slice to inherit:
+It's recommended to define a base scope for the other scopes in the app or slice to inherit:
 
 ```ruby
 # app/views/scope.rb


### PR DESCRIPTION
While talking about scopes, the guides mention parts, instead of scopes

![2024-04-14_11-55](https://github.com/hanami/guides/assets/25006471/86e1efad-96d4-4207-a30d-634b6812d9ed)
