### PR TITLE
Update building-an-api.md

### DIFF
--- a/content/v2.2/introduction/building-an-api.md
+++ b/content/v2.2/introduction/building-an-api.md
@@ -576,7 +576,7 @@ And in the repo, we can use these to control the pagination:
 
 module Bookshelf
   module Repos
-    class BookRepo < Bookshelf::Repo
+    class BookRepo < Bookshelf::DB::Repo
       def all_by_title(page:, per_page:)
         books
           .select(:title, :author)


### PR DESCRIPTION
DB lack on book_repo.rb definition.

I think was a typho, lack of DB word on upper class in book_repos.rb.
