### PR TITLE
Add note about first action format being default

### DIFF
--- a/content/v2.0/actions/formats-and-mime-types.md
+++ b/content/v2.0/actions/formats-and-mime-types.md
@@ -188,12 +188,15 @@ If you need your actions to work with additional MIME types, you can configure t
 
 module Bookshelf
   class App < Hanami::App
+    # config.actions.formats.add :html
     config.actions.formats.add :custom, "application/custom"
   end
 end
 ```
 
 This will add the `:custom` format for the `"application/custom"` MIME type and also configure your actions to use this format.
+
+The **first format added will be the default format**, so you likely want to add `:html` or `:json` before any custom formats.
 
 You can also configure a format to map to multiple MIME types:
 

--- a/content/v2.1/actions/formats-and-mime-types.md
+++ b/content/v2.1/actions/formats-and-mime-types.md
@@ -188,12 +188,15 @@ If you need your actions to work with additional MIME types, you can configure t
 
 module Bookshelf
   class App < Hanami::App
+    # config.actions.formats.add :html
     config.actions.formats.add :custom, "application/custom"
   end
 end
 ```
 
 This will add the `:custom` format for the `"application/custom"` MIME type and also configure your actions to use this format.
+
+The **first format added will be the default format**, so you likely want to add `:html` or `:json` before any custom formats.
 
 You can also configure a format to map to multiple MIME types:
 

--- a/content/v2.2/actions/formats-and-mime-types.md
+++ b/content/v2.2/actions/formats-and-mime-types.md
@@ -188,12 +188,15 @@ If you need your actions to work with additional MIME types, you can configure t
 
 module Bookshelf
   class App < Hanami::App
+    # config.actions.formats.add :html
     config.actions.formats.add :custom, "application/custom"
   end
 end
 ```
 
 This will add the `:custom` format for the `"application/custom"` MIME type and also configure your actions to use this format.
+
+The **first format added will be the default format**, so you likely want to add `:html` or `:json` before any custom formats.
 
 You can also configure a format to map to multiple MIME types:
 


### PR DESCRIPTION
[A couple people ran into this issue where they added a custom MIME format](https://github.com/hanami/hanami/issues/1396) and didn't expect that would mean the rest of their HTML requests (without `Accepts` or `Content-Type` headers) would break.

So we should document this, at least. Open to suggestions of how to word this better.