### PR TITLE
Add `bundle install` step to the getting started guide

### DIFF
--- a/content/v2.1/introduction/getting-started.md
+++ b/content/v2.1/introduction/getting-started.md
@@ -141,6 +141,7 @@ We'll see this structure in more detail as this guide progresses.
 For now let's get our new app running. In the bookshelf directory, run:
 
 ```shell
+$ bundle install
 $ bundle exec hanami dev
 ```
 


### PR DESCRIPTION
When I was following the guide I had to do this step manually, and those who are newer to the Ruby ecosystem might not know this command is required before the `bundle exec hanami dev` command.

I hope this is helpful! Happy to change as needed! (Or maybe I did something wrong?)

Best,
Pat