### PR TITLE
[Guides] Add Hanami CLI documentation for DB commands

### DIFF
--- a/content/v2.2/cli-commands/assets.md
+++ b/content/v2.2/cli-commands/assets.md
@@ -1,6 +1,6 @@
 ---
 title: Assets
-order: 100
+order: 110
 ---
 
 ## hanami assets compile

--- a/content/v2.2/cli-commands/commands.md
+++ b/content/v2.2/cli-commands/commands.md
@@ -28,6 +28,7 @@ $ bundle exec hanami --help
 Commands:
   hanami assets [SUBCOMMAND]
   hanami console                              # Start app console (REPL)
+    hanami db [SUBCOMMAND]
   hanami dev                                  # Start the application in development mode
   hanami generate [SUBCOMMAND]
   hanami install                              # Install Hanami third-party plugins

--- a/content/v2.2/cli-commands/db.md
+++ b/content/v2.2/cli-commands/db.md
@@ -5,7 +5,7 @@ order: 110
 
 ## hanami db
 
-Hanami supports multiple database-related CLI commands, to help manage databases and their schemas for your app. You can list all of them, by adding the `--help` option.
+Hanami provides commands to manage all aspects of your database’s lifecycle. List all the commands with the `--help` option.
 
 ```shell
 $ bundle exec hanami db --help
@@ -20,296 +20,61 @@ Commands:
   hanami db version                                 # Print schema version
 ```
 
-### hanami db create
-Allows to create the database for the current environment.
+Each of the commands below will target all the databases in your app and slices by default. To target an individual database, provide an `--app` or `--slice=SLICE` option, as well as `--gateway=GATEWAY` if you have multiple gateways configured.
 
-```shell
-$ bundle exec hanami db create
+## hanami db create
 
-# => database db/bookshelf.sqlite created
-```
+Creates the databases for the current environment.
 
-The DB name is fetched from the `DATABASE_URL` environment variable.
+## hanami db drop
 
-```yaml
-# .env
-DATABASE_URL=sqlite://db/bookshelf.sqlite
-```
+Drops the databases for the current environment.
 
-The command will accept options listed below.
+## hanami db migrate
 
-```shell
-  --app                             # Use app database, default: false
-  --slice=VALUE                     # Use database for slice
-  --gateway=VALUE                   # Use database for gateway
-  --help, -h                        # Print this help
-```
+Runs migrations to apply changes to the app's databases.
 
-**Create slice database**
-
-You can have separate databases for your slices without any additional configuration. The only thing needed is to define the `DATABASE_URL` environment variable for your slice. You can do it, by *prepending* the `DATABASE_URL` with your slice name, separating it by `__` (**double underscore**). Here is a quick example:
-
-```shell
-# quickly generate the new slice if you don't have one.
-$ bundle exec hanami g slice Admin
-```
-
-```ruby
-# .env
-DATABASE_URL=sqlite://db/bookshelf.sqlite
-
-ADMIN__DATABASE_URL=sqlite://slices/admin/config/db/bookshelf.sqlite
-```
-
-Now, when you'll run the command with the `--slice` option, separate db will be created for your slice.
-
-```shell
-$ bundle exec hanami db create
-
-# => database slices/admin/config/db/bookshelf.sqlite created
-```
-
-
-**Specify DB gateway**
-
-Hanami supports multiple databases on the slice but also relation level. We can mix the `--app` or `--slice` flag with `--gateway` option, to specify what DB to create. The only thing needed is to define the separate `DATABASE_URL` environment variable for your gateway. You can do it, by *appending* the `DATABASE_URL` with your slice name, separating it by `__` (**double underscore**). Here is a quick example:
-
-Below we assume, that there is a general `bookshelf` database for reading data, and an `event_store` used for writing parts and making business decisions.  Then within the `Admin` slice, we want to have a separate database to store `Personally identifiable information`.
-
-```ruby
-# .env
-DATABASE_URL=sqlite://db/bookshelf.sqlite
-
-DATABASE_URL__EVENT_STORE=sqlite://db/event_store.sqlite
-
-ADMIN__DATABASE_URL=sqlite://slices/admin/config/db/bookshelf.sqlite
-ADMIN__DATABASE_URL__PII=sqlite://slices/admin/config/db/pii.sqlite
-```
-
-```shell
-$ bundle exec hanami db create --gateway=event_store --app
-# => database db/event_store.sqlite created
-
-$ bundle exec hanami db create --gateway=pii --slice=admin
-# => database slices/admin/config/db/pii.sqlite created
-```
-
-**Multiple databases created automatically**
-
-If you won't specify options, all matching databases will be created at once.
-
-```shell
-=> database db/bookshelf.sqlite created
-=> database db/event_store.sqlite created
-=> database slices/admin/config/db/bookshelf.sqlite created
-=> database slices/admin/config/db/pii.sqlite created
-```
-
-### hanami db drop
-Allows to drop the databases for the current environment. Similar to other DB commands, it works based on `ENV` variables configuration for `DATABASE_URL` of main app, slices and gateways (Check:[hanami db create](#hanami-db-create) for examples about options)
-
-```shell
-$ bundle exec hanami db drop
-=> database db/bookshelf.sqlite dropped
-```
-
-The command will accept options listed below.
-
-```shell
-  --app                             # Use app database, default: false
-  --slice=VALUE                     # Use database for slice
-  --gateway=VALUE                   # Use database for gateway
-  --help, -h                        # Print this help
-```
-
-
-**Multiple databases dropped automatically**
-
-If you don't specify options, all configured databases will be dropped at once.
-
-```ruby
-# .env
-DATABASE_URL=sqlite://db/bookshelf.sqlite
-
-DATABASE_URL__EVENT_STORE=sqlite://db/event_store.sqlite
-
-ADMIN__DATABASE_URL=sqlite://slices/admin/config/db/bookshelf.sqlite
-ADMIN__DATABASE_URL__PII=sqlite://slices/admin/config/db/pii.sqlite
-```
-
-```shell
-=> database db/bookshelf.sqlite dropped
-=> database db/event_store.sqlite dropped
-=> database slices/admin/config/db/bookshelf.sqlite dropped
-=> database slices/admin/config/db/pii.sqlite dropped
-```
-
-### hanami db migrate
-This command will run migrations for all configured databases in the app.
-
-```shell
-$ bundle exec hanami db migrate
-# => database db/bookshelf.sqlite migrated in 0.0019s
-```
-
-The command will accept options listed below.
-
-```shell
-  --app                             # Use app database, default: false
-  --slice=VALUE                     # Use database for slice
-  --gateway=VALUE                   # Use database for gateway
-  --target=VALUE, -t VALUE          # Target migration number
-  --[no-]dump                       # Dump the database structure after migrating, default: true
-  --help, -h                        # Print this help
-```
-
-For examples how to run migrations only for main app, specified slice or gateway, check the [hanami db create](#hanami-db-create) section.
-
-**Migration folders**
-
-Migrations for the default app database, are stored in `db/migrate` folder. Each gateway or slice will expect to have separate folders to store migrations.
-
-```text
-# migrations for default app database. 
-# Example: DATABASE_URL => 'db/migrate'
-db/migrate
-
-# migrations for <<gateway_name>> app databases.
-# Example: DATABASE_URL_EVENT_STORE => 'db/event_store_migrate'
-db/<<gateway_name>>_migrate
-
-# migrations for default slice databases.
-# example: ADMIN__DATABASE_URL => 'slices/admin/config/db/migrate'
-slices/<<slice_name>>/config/db/migrate
-
-# migrations for per-slice gateway databases
-# example: ADMIN__DATABASE_URL_PII => 'slices/admin/config/db/pii_migrate'
-slices/<<slice_name>>/config/db/<<gateway>>_migrate
-```
-
-**Generating db dumps**
-
-By default, you'll get the *_structure.sql file describing the schema for each database. If you wish to skip this behavior, you can pass the `--no-dump` option.
-
-```shell
-$ bundle exec hanami db migrate --no-dump
-# => database db/bookshelf.sqlite migrated in 0.0004s
-```
-
-As you can see, this part is a bit faster, which may be useful for speeding up the CI setup.
-
-**Migrating forward or backward to the specified version**
-
-You can migrate to any migration version, by passing the migration file timestamp in the `--target` option.
+To migrate to a specific version (forwards or backwards), provide the `--target` option, along with the timestamp of the target migration.
 
 ```shell
 $ bundle exec hanami db migrate --target=20241009134756
 ```
 
+To migrate to the beginning, provide `--target=0`.
 
-You can quickly rollback all the way down using `--target=0`
+By default, migrating will also generate a structure dump file (such a `config/db/structure.sql`). To skip this, provide the `--no-dump` flag.
 
-```shell
- $ bundle exec hanami db migrate --target=0 # rollbacks all migrations
-```
+For more on migrations, see the [migrations guide](/v2.2/database/migrations/).
 
-### hanami db prepare
-Preparing DB means, creating all configured databases, and running migrations for all of them.
+## hanami db prepare
 
-```shell
-$ bundle exec hanami db prepare
-# => database db/bookshelf.sqlite migrated in 0.0005s
-# => db/bookshelf.sqlite structure dumped to config/db/structure.sql in 0.019s
-```
+Prepares the app's databases for use, from whatever state they may be in.
 
-The command will accept options listed below.
+For each database, runs the following commands:
 
-```shell
-  --app                             # Use app database, default: false
-  --slice=VALUE                     # Use database for slice
-  --help, -h                        # Print this help
-```
+- `db create` (if the database does not exist)
+- `db structure load` (if the database does not exist)
+- `db migrate`
+- `db seed` (once per slice only)
 
-For examples how to run db preparation only for main app, or specified slice, check the [hanami db create](#hanami-db-create) section.
-### hanami db seed
-Allows to seed data to databases for main app or any slice.
+This command operates idempotently, so you can run it at any stage of your development process.
 
-```shell
-$ bundle exec hanami db seed
-```
+## hanami db seed
 
-The command will accept options listed below.
+Loads and executes the seeds files for your app and slices. These are located at `config/db/seeds.rb`.
 
-```shell
-  --app                             # Use app database, default: false
-  --slice=VALUE                     # Use database for slice
-  --help, -h                        # Print this help
+These seed files should create the database records required to run the app. The code in these files be idempotent so that it can be executed at any time.
 
-```
+## hanami db structure dump
 
-For examples how to seed data only for main app, or specified slice, check the [hanami db create](#hanami-db-create) section.
+Dumps the structure of the app's databases into `structure.sql` files.
 
-**Seed file paths**
+## hanami db structure load
 
-Seeding data assumes you have `seed.rb` files under the correct paths.
+Prepares the app's databases structure by executing their `structure.sql` files.
 
-```shell
-# app seeds
-config/db/seeds.rb
+This is a faster way to bring a new database into a ready state compared to re-running all historical migrations.
 
-# per-slice seeds
-# Example: slices/admin/config/db/seeds.rb
-slices/<<slice>>/config/db/seeds.rb
-```
+## hanami db version
 
-### hanami db structure dump
-Allows to dump all or any specific database structure into the `structure.sql` file. If no options provided, it'll dump all configured database structures.
-
-```shell
-$ bundle exec hanami db structure dump
-# => db/bookshelf.sqlite structure dumped to config/db/structure.sql in 0.0851s
-# => db/event_store.sqlite structure dumped to config/db/event_store_structure.sql in 0.018s
-# => slices/admin/config/db/bookshelf.sqlite structure dumped to slices/main/config/db/structure.sql in 0.0174s
-# => slices/admin/config/db/pii.sqlite structure dumped to slices/main/config/db/pii_structure.sql in 0.0173s
-```
-
-The command will accept options listed below
-
-```shell
-  --app                             # Use app database, default: false
-  --slice=VALUE                     # Use database for slice
-  --gateway=VALUE                   # Use database for gateway
-  --help, -h                        # Print this help
-```
-
-For examples how to run db structure dump only for main app, or specified slice, check the [hanami db create](#hanami-db-create) section.
-
-### hanami db structure load
-Allows to load all or any specific database structure from the `structure.sql` files, instead of running migrations one after the other, which may be much faster. If no options provided, it'll dump all configured database structures.
-
-```shell
-hanami db create # create empty databases first
-hanami db structure load
-# => db/bookshelf.sqlite structure loaded from config/db/structure.sql in 0.0164s
-# => db/event_store.sqlite structure loaded from config/db/event_store_structure.sql in 0.0139s
-# => slices/main/config/db/bookshelf.sqlite structure loaded from slices/admin/config/db/structure.sql in 0.0175s
-# => slices/main/config/db/pii.sqlite structure loaded from slices/admin/config/db/pii_structure.sql in 0.0176s
-```
-
-The command will accept options listed below
-
-```shell
-  --app                             # Use app database, default: false
-  --slice=VALUE                     # Use database for slice
-  --gateway=VALUE                   # Use database for gateway
-  --help, -h                        # Print this help
-```
-
-For examples how to load db structure only for main app, or specified slice, check the [hanami db create](#hanami-db-create) section.
-### hanami db version
-Prints current schema version for all databases:
-
-```shell
-$ bundle exec hanami db version
-# => db/bookshelf.sqlite current schema version is 20241009140151_add_books_table
-```
+Prints current schema version for the app's databases.

--- a/content/v2.2/cli-commands/db.md
+++ b/content/v2.2/cli-commands/db.md
@@ -1,0 +1,116 @@
+---
+title: Routes
+order: 110
+---
+
+## hanami db
+
+Hanami supports multiple database-related CLI commands, to help manage databases and their schemas for your app. You can list all of them, by adding the `--help` option.
+
+```shell
+$ bundle exec hanami db --help
+
+Commands:
+  hanami db create                                  # Create databases
+  hanami db drop                                    # Delete databases
+  hanami db migrate                                 # Migrates database
+  hanami db prepare                                 # Prepare databases
+  hanami db seed                                    # Load seed data
+  hanami db structure [SUBCOMMAND]
+  hanami db version                                 # Print schema version
+```
+
+### hanami db create
+Allows to create the database for the current environment.
+
+```shell
+$ bundle exec hanami db create
+
+# => database db/bookshelf.sqlite created
+```
+
+The DB name is fetched from the `DATABASE_URL` environment variable.
+
+```yaml
+# .env
+DATABASE_URL=sqlite://db/bookshelf.sqlite
+```
+
+The command will accept options listed below.
+
+```shell
+  --app                             # Use app database, default: false
+  --slice=VALUE                     # Use database for slice
+  --gateway=VALUE                   # Use database for gateway
+  --help, -h                        # Print this help
+```
+
+**Create slice database**
+
+You can have separate databases for your slices without any additional configuration. The only thing needed is to define the `DATABASE_URL` environment variable for your slice. You can do it, by *prepending* the `DATABASE_URL` with your slice name, separating it by `__` (**double underscore**). Here is a quick example:
+
+```shell
+# quickly generate the new slice if you don't have one.
+$ bundle exec hanami g slice Admin
+```
+
+```ruby
+# .env
+DATABASE_URL=sqlite://db/bookshelf.sqlite
+
+ADMIN__DATABASE_URL=sqlite://slices/admin/config/db/bookshelf.sqlite
+```
+
+Now, when you'll run the command with the `--slice` option, separate db will be created for your slice.
+
+```shell
+$ bundle exec hanami db create
+
+# => database slices/admin/config/db/bookshelf.sqlite created
+```
+
+
+**Specify DB gateway**
+
+Hanami supports multiple databases on the slice but also relation level. We can mix the `--app` or `--slice` flag with `--gateway` option, to specify what DB to create. The only thing needed is to define the separate `DATABASE_URL` environment variable for your gateway. You can do it, by *appending* the `DATABASE_URL` with your slice name, separating it by `__` (**double underscore**). Here is a quick example:
+
+Below we assume, that there is a general `bookshelf` database for reading data, and an `event_store` used for writing parts and making business decisions.  Then within the `Admin` slice, we want to have a separate database to store `Personally identifiable information`.
+
+```ruby
+# .env
+DATABASE_URL=sqlite://db/bookshelf.sqlite
+
+DATABASE_URL__EVENT_STORE=sqlite://db/event_store.sqlite
+
+ADMIN__DATABASE_URL=sqlite://slices/admin/config/db/bookshelf.sqlite
+ADMIN__DATABASE_URL__PII=sqlite://slices/admin/config/db/pii.sqlite
+```
+
+```shell
+$ bundle exec hanami db create --gateway=event_store --app
+# => database db/event_store.sqlite created
+
+$ bundle exec hanami db create --gateway=pii --slice=admin
+# => database slices/admin/config/db/pii.sqlite created
+```
+
+**Multiple databases created automatically**
+
+If you won't specify options, all matching databases will be created at once.
+
+```shell
+=> database db/bookshelf.sqlite created
+=> database db/event_store.sqlite created
+=> database slices/admin/config/db/bookshelf.sqlite created
+=> database slices/admin/config/db/pii.sqlite created
+```
+
+```
+
+```shell
+=> database db/bookshelf.sqlite created
+=> database db/event_store.sqlite created
+=> database slices/admin/config/db/bookshelf.sqlite created
+=> database slices/admin/config/db/pii.sqlite created
+```
+

--- a/content/v2.2/cli-commands/db.md
+++ b/content/v2.2/cli-commands/db.md
@@ -144,3 +144,91 @@ ADMIN__DATABASE_URL__PII=sqlite://slices/admin/config/db/pii.sqlite
 => database slices/admin/config/db/pii.sqlite dropped
 ```
 
+### hanami db migrate
+This command will run migrations for all configured databases in the app.
+
+```shell
+$ bundle exec hanami db migrate
+# => database db/bookshelf.sqlite migrated in 0.0019s
+```
+
+The command will accept options listed below.
+
+```shell
+  --app                             # Use app database, default: false
+  --slice=VALUE                     # Use database for slice
+  --gateway=VALUE                   # Use database for gateway
+  --target=VALUE, -t VALUE          # Target migration number
+  --[no-]dump                       # Dump the database structure after migrating, default: true
+  --help, -h                        # Print this help
+```
+
+For examples how to run migrations only for main app, specified slice or gateway, check the [hanami db create](#hanami-db-create) section.
+
+**Migration folders**
+
+Migrations for the default app database, are stored in `db/migrate` folder. Each gateway or slice will expect to have separate folders to store migrations.
+
+```text
+# migrations for default app database. 
+# Example: DATABASE_URL => 'db/migrate'
+db/migrate
+
+# migrations for <<gateway_name>> app databases.
+# Example: DATABASE_URL_EVENT_STORE => 'db/event_store_migrate'
+db/<<gateway_name>>_migrate
+
+# migrations for default slice databases.
+# example: ADMIN__DATABASE_URL => 'slices/admin/config/db/migrate'
+slices/<<slice_name>>/config/db/migrate
+
+# migrations for per-slice gateway databases
+# example: ADMIN__DATABASE_URL_PII => 'slices/admin/config/db/pii_migrate'
+slices/<<slice_name>>/config/db/<<gateway>>_migrate
+```
+
+**Generating db dumps**
+
+By default, you'll get the *_structure.sql file describing the schema for each database. If you wish to skip this behavior, you can pass the `--no-dump` option.
+
+```shell
+$ bundle exec hanami db migrate --no-dump
+# => database db/bookshelf.sqlite migrated in 0.0004s
+```
+
+As you can see, this part is a bit faster, which may be useful for speeding up the CI setup.
+
+**Migrating forward or backward to the specified version**
+
+You can migrate to any migration version, by passing the migration file timestamp in the `--target` option.
+
+```shell
+$ bundle exec hanami db migrate --target=20241009134756
+```
+
+
+You can quickly rollback all the way down using `--target=0`
+
+```shell
+ $ bundle exec hanami db migrate --target=0 # rollbacks all migrations
+```
+
+### hanami db prepare
+Preparing DB means, creating all configured databases, and running migrations for all of them.
+
+```shell
+$ bundle exec hanami db prepare
+# => database db/bookshelf.sqlite migrated in 0.0005s
+# => db/bookshelf.sqlite structure dumped to config/db/structure.sql in 0.019s
+```
+
+The command will accept options listed below.
+
+```shell
+  --app                             # Use app database, default: false
+  --slice=VALUE                     # Use database for slice
+  --help, -h                        # Print this help
+```
+
+For examples how to run db preparation only for main app, or specified slice, check the [hanami db create](#hanami-db-create) section.
+

--- a/content/v2.2/cli-commands/db.md
+++ b/content/v2.2/cli-commands/db.md
@@ -105,12 +105,42 @@ If you won't specify options, all matching databases will be created at once.
 => database slices/admin/config/db/pii.sqlite created
 ```
 
+### hanami db drop
+Allows to drop the databases for the current environment. Similar to other DB commands, it works based on `ENV` variables configuration for `DATABASE_URL` of main app, slices and gateways (Check:[hanami db create](#hanami-db-create) for examples about options)
+
+```shell
+$ bundle exec hanami db drop
+=> database db/bookshelf.sqlite dropped
+```
+
+The command will accept options listed below.
+
+```shell
+  --app                             # Use app database, default: false
+  --slice=VALUE                     # Use database for slice
+  --gateway=VALUE                   # Use database for gateway
+  --help, -h                        # Print this help
+```
+
+
+**Multiple databases dropped automatically**
+
+If you don't specify options, all configured databases will be dropped at once.
+
+```ruby
+# .env
+DATABASE_URL=sqlite://db/bookshelf.sqlite
+
+DATABASE_URL__EVENT_STORE=sqlite://db/event_store.sqlite
+
+ADMIN__DATABASE_URL=sqlite://slices/admin/config/db/bookshelf.sqlite
+ADMIN__DATABASE_URL__PII=sqlite://slices/admin/config/db/pii.sqlite
 ```
 
 ```shell
-=> database db/bookshelf.sqlite created
-=> database db/event_store.sqlite created
-=> database slices/admin/config/db/bookshelf.sqlite created
-=> database slices/admin/config/db/pii.sqlite created
+=> database db/bookshelf.sqlite dropped
+=> database db/event_store.sqlite dropped
+=> database slices/admin/config/db/bookshelf.sqlite dropped
+=> database slices/admin/config/db/pii.sqlite dropped
 ```
 

--- a/content/v2.2/cli-commands/db.md
+++ b/content/v2.2/cli-commands/db.md
@@ -1,6 +1,6 @@
 ---
-title: Routes
-order: 110
+title: DB
+order: 80
 ---
 
 ## hanami db

--- a/content/v2.2/cli-commands/db.md
+++ b/content/v2.2/cli-commands/db.md
@@ -231,4 +231,85 @@ The command will accept options listed below.
 ```
 
 For examples how to run db preparation only for main app, or specified slice, check the [hanami db create](#hanami-db-create) section.
+### hanami db seed
+Allows to seed data to databases for main app or any slice.
 
+```shell
+$ bundle exec hanami db seed
+```
+
+The command will accept options listed below.
+
+```shell
+  --app                             # Use app database, default: false
+  --slice=VALUE                     # Use database for slice
+  --help, -h                        # Print this help
+
+```
+
+For examples how to seed data only for main app, or specified slice, check the [hanami db create](#hanami-db-create) section.
+
+**Seed file paths**
+
+Seeding data assumes you have `seed.rb` files under the correct paths.
+
+```shell
+# app seeds
+config/db/seeds.rb
+
+# per-slice seeds
+# Example: slices/admin/config/db/seeds.rb
+slices/<<slice>>/config/db/seeds.rb
+```
+
+### hanami db structure dump
+Allows to dump all or any specific database structure into the `structure.sql` file. If no options provided, it'll dump all configured database structures.
+
+```shell
+$ bundle exec hanami db structure dump
+# => db/bookshelf.sqlite structure dumped to config/db/structure.sql in 0.0851s
+# => db/event_store.sqlite structure dumped to config/db/event_store_structure.sql in 0.018s
+# => slices/admin/config/db/bookshelf.sqlite structure dumped to slices/main/config/db/structure.sql in 0.0174s
+# => slices/admin/config/db/pii.sqlite structure dumped to slices/main/config/db/pii_structure.sql in 0.0173s
+```
+
+The command will accept options listed below
+
+```shell
+  --app                             # Use app database, default: false
+  --slice=VALUE                     # Use database for slice
+  --gateway=VALUE                   # Use database for gateway
+  --help, -h                        # Print this help
+```
+
+For examples how to run db structure dump only for main app, or specified slice, check the [hanami db create](#hanami-db-create) section.
+
+### hanami db structure load
+Allows to load all or any specific database structure from the `structure.sql` files, instead of running migrations one after the other, which may be much faster. If no options provided, it'll dump all configured database structures.
+
+```shell
+hanami db create # create empty databases first
+hanami db structure load
+# => db/bookshelf.sqlite structure loaded from config/db/structure.sql in 0.0164s
+# => db/event_store.sqlite structure loaded from config/db/event_store_structure.sql in 0.0139s
+# => slices/main/config/db/bookshelf.sqlite structure loaded from slices/admin/config/db/structure.sql in 0.0175s
+# => slices/main/config/db/pii.sqlite structure loaded from slices/admin/config/db/pii_structure.sql in 0.0176s
+```
+
+The command will accept options listed below
+
+```shell
+  --app                             # Use app database, default: false
+  --slice=VALUE                     # Use database for slice
+  --gateway=VALUE                   # Use database for gateway
+  --help, -h                        # Print this help
+```
+
+For examples how to load db structure only for main app, or specified slice, check the [hanami db create](#hanami-db-create) section.
+### hanami db version
+Prints current schema version for all databases:
+
+```shell
+$ bundle exec hanami db version
+# => db/bookshelf.sqlite current schema version is 20241009140151_add_books_table
+```

--- a/content/v2.2/cli-commands/generate.md
+++ b/content/v2.2/cli-commands/generate.md
@@ -1,6 +1,6 @@
 ---
 title: Generate
-order: 90
+order: 70
 ---
 
 ## hanami generate

--- a/content/v2.2/cli-commands/middleware.md
+++ b/content/v2.2/cli-commands/middleware.md
@@ -1,6 +1,6 @@
 ---
 title: Middleware
-order: 80
+order: 100
 ---
 
 ## hanami middleware

--- a/content/v2.2/cli-commands/routes.md
+++ b/content/v2.2/cli-commands/routes.md
@@ -1,6 +1,6 @@
 ---
 title: Routes
-order: 70
+order: 90
 ---
 
 ## hanami routes

--- a/content/v2.2/cli-commands/version.md
+++ b/content/v2.2/cli-commands/version.md
@@ -1,6 +1,6 @@
 ---
 title: Version
-order: 110
+order: 120
 ---
 
 ## hanami version


### PR DESCRIPTION
### Background.

For the CLI section, we'll need to have information about CLI commands for DB namespace.

### Design

Follow the same convention as with other CLI command docs.