### PR TITLE
Remove separate db commands for test env

### DIFF
--- a/content/v2.2/introduction/building-a-web-app.md
+++ b/content/v2.2/introduction/building-a-web-app.md
@@ -349,11 +349,10 @@ ROM::SQL.migration do
 end
 ```
 
-Migrate both the development and test databases:
+Migrate the development and test databases:
 
 ```shell
 $ bundle exec hanami db migrate
-$ HANAMI_ENV=test bundle exec hanami db migrate
 ```
 
 Next, let's generate a relation to allow our app to interact with our books table. To generate a relation:

--- a/content/v2.2/introduction/building-an-api.md
+++ b/content/v2.2/introduction/building-an-api.md
@@ -321,11 +321,10 @@ ROM::SQL.migration do
 end
 ```
 
-Migrate both the development and test databases:
+Migrate the development and test databases:
 
 ```shell
 $ bundle exec hanami db migrate
-$ HANAMI_ENV=test bundle exec hanami db migrate
 ```
 
 Next, let's generate a relation to allow our app to interact with our books table. To generate a relation:


### PR DESCRIPTION
When executed in the development env, these commands will now operate on both the development _and_ test databases, saving us the extra work!