### PR TITLE
Update getting started guides for 2.2

### DIFF
--- a/content/v2.2/introduction/building-a-web-app.md
+++ b/content/v2.2/introduction/building-a-web-app.md
@@ -121,7 +121,7 @@ As this error suggests, we need to create the home show action the route is expe
 Hanami provides an action generator we can use to create this action. Running this command will create the home show action:
 
 ```shell
-$ bundle exec hanami generate action home.index --skip-route
+$ bundle exec hanami generate action home.index --skip-route --skip-tests
 ```
 
 We can find this action in our `app` directory at `app/actions/home/index.rb`:
@@ -261,7 +261,7 @@ Finished in 0.09789 seconds (files took 0.57724 seconds to load)
 Let's fix that by generating an action for a books index:
 
 ```shell
-$ bundle exec hanami generate action books.index
+$ bundle exec hanami generate action books.index --skip-tests
 ```
 
 In addition to generating an action at `app/actions/books/index.rb` and a view at `app/views/books/index.rb`, the generator has also added a route in `config/routes.rb`:
@@ -648,7 +648,7 @@ Failures:
 We can use Hanami's action generator to create both a route and an action. Run:
 
 ```shell
-$ bundle exec hanami generate action books.show
+$ bundle exec hanami generate action books.show --skip-tests
 ```
 
 If you inspect `config/routes.rb` you will see the generator has automatically added a new `get "/books/:id", to: "books.show"` route:
@@ -897,13 +897,13 @@ Running this spec, we see failures due to the title field being missing. This is
 Hanami's action generator can take care of this for us:
 
 ```shell
-$ bundle exec hanami generate action books.new
+$ bundle exec hanami generate action books.new --skip-tests
 ```
 
 Let's also generate a matching create action:
 
 ```shell
-$ bundle exec hanami generate action books.create
+$ bundle exec hanami generate action books.create --skip-tests
 ```
 
 The app's routes now include the expected routes - invoking the `books.new` action for GET requests to `/books/new`, and the `books.create` action for `POST` requests to `/books`:

--- a/content/v2.2/introduction/building-a-web-app.md
+++ b/content/v2.2/introduction/building-a-web-app.md
@@ -93,7 +93,7 @@ To help make our spec pass, let's add a route to invoke a new action.
 
 module Bookshelf
   class Routes < Hanami::Routes
-    root to: "home.show"
+    root to: "home.index"
   end
 end
 ```
@@ -109,9 +109,9 @@ Failures:
      Failure/Error: get "/"
 
      Hanami::Routes::MissingActionError:
-       Could not find action with key "actions.home.show" in Bookshelf::App
+       Could not find action with key "actions.home.index" in Bookshelf::App
 
-       To fix this, define the action class Bookshelf::Actions::Home::Show in /Users/jane/bookshelf/actions/home/show.rb
+       To fix this, define the action class Bookshelf::Actions::Home::Index in /Users/jane/bookshelf/actions/home/index.rb
 
 1 example, 1 failure
 ```
@@ -121,18 +121,18 @@ As this error suggests, we need to create the home show action the route is expe
 Hanami provides an action generator we can use to create this action. Running this command will create the home show action:
 
 ```shell
-$ bundle exec hanami generate action home.show
+$ bundle exec hanami generate action home.index --skip-route
 ```
 
-We can find this action in our `app` directory at `app/actions/home/show.rb`:
+We can find this action in our `app` directory at `app/actions/home/index.rb`:
 
 ```ruby
-# app/actions/home/show.rb
+# app/actions/home/index.rb
 
 module Bookshelf
   module Actions
     module Home
-      class Show < Bookshelf::Action
+      class Index < Bookshelf::Action
         def handle(request, response)
         end
       end
@@ -153,15 +153,15 @@ end
 
 For more details on actions, see the [Actions guide](/v2.2/actions/overview/).
 
-By default, an action will render its equivalent view. We can find our new view in our `app` directory at `app/views/home/show.rb`:
+By default, an action will render its equivalent view. We can find our new view in our `app` directory at `app/views/home/index.rb`:
 
 ```ruby
-# app/views/home/show.rb
+# app/views/home/index.rb
 
 module Bookshelf
   module Views
     module Home
-      class Show < Bookshelf::View
+      class Index < Bookshelf::View
       end
     end
   end
@@ -170,10 +170,10 @@ end
 
 Just like actions, every view in a Hanami app is an individual class. Views prepare the values to be passed to a template, then render that template to generate their output.
 
-We can find this view's template in our `app` directory at `app/templates/home/show.html.erb`. Let's adjust this template to include our desired "Welcome to Bookshelf" text.
+We can find this view's template in our `app` directory at `app/templates/home/index.html.erb`. Let's adjust this template to include our desired "Welcome to Bookshelf" text.
 
 ```sql
-# app/templates/home/show.html.erb
+# app/templates/home/index.html.erb
 
 <h1>Welcome to Bookshelf</h1>
 ```
@@ -269,7 +269,7 @@ In addition to generating an action at `app/actions/books/index.rb` and a view a
 ```ruby
 module Bookshelf
   class Routes < Hanami::Routes
-    root to: "home.show"
+    root to: "home.index"
     get "/books", to: "books.index"
   end
 end
@@ -330,7 +330,7 @@ Of course, returning a static list of books is not particularly useful. Let's ad
 To create a books table, we need to generate a migration:
 
 ```shell
-$ hanami generate migration create_books
+$ bundle exec hanami generate migration create_books
 ```
 
 Edit the migration file to create a books table with title and author columns and a primary key:
@@ -480,7 +480,7 @@ Of course, returning _every_ book in the database when a visitor makes a request
 module Bookshelf
   module Relations
     class Books < Bookshelf::DB::Relation
-      schema(:books, infer: true)
+      schema :books, infer: true
 
       use :pagination
       per_page 5
@@ -724,9 +724,9 @@ Lastly, we can populate the template.
 ```sql
 <!-- app/views/books/show.html.erb -->
 
-<h1><%= book[:title] %></h1>
+<h1><%= book.title %></h1>
 
-<p>By <%= book[:author] %></p>
+<p>By <%= book.author %></p>
 ```
 
 With this, our happy path test passes, but the test for our 404 now fails:
@@ -746,7 +746,7 @@ Failures:
      Failure/Error: <h1><%= book[:title] %></h1>
 
      NoMethodError:
-       undefined method `[]' for nil
+       undefined method `title' for nil
      # ./app/templates/books/show.html.erb:1:in `__tilt_8300'
      # ./app/actions/books/show.rb:8:in `handle'
      # ./spec/features/books/show_spec.rb:19:in `block (3 levels) in <top (required)>'

--- a/content/v2.2/introduction/building-an-api.md
+++ b/content/v2.2/introduction/building-an-api.md
@@ -100,7 +100,7 @@ Let's update our routes to invoke an action for our app's root, which handles `G
 
 module Bookshelf
   class Routes < Hanami::Routes
-    root to: "home.show"
+    root to: "home.index"
   end
 end
 ```
@@ -116,9 +116,9 @@ Failures:
      Failure/Error: get "/"
 
      Hanami::Routes::MissingActionError:
-       Could not find action with key "actions.home.show" in Bookshelf::App
+       Could not find action with key "actions.home.index" in Bookshelf::App
 
-       To fix this, define the action class Bookshelf::Actions::Home::Show in app/actions/home/show.rb
+       To fix this, define the action class Bookshelf::Actions::Home::Index in app/actions/home/index.rb
      # ./spec/requests/root_spec.rb:5:in `block (2 levels) in <top (required)>'
 
 Finished in 0.01871 seconds (files took 0.62516 seconds to load)
@@ -130,10 +130,10 @@ As this error suggests, we need to create the home show action the route is expe
 Hanami provides an action generator we can use to create this action. Running this command will create the home show action:
 
 ```shell
-$ bundle exec hanami generate action home.show --skip-view
+$ bundle exec hanami generate action home.index --skip-view --skip-route --skip-tests
 ```
 
-We can find this action in our `app` directory at `app/actions/home/show.rb`:
+We can find this action in our `app` directory at `app/actions/home/index.rb`:
 
 ```ruby
 # app/actions/home/show.rb
@@ -141,7 +141,7 @@ We can find this action in our `app` directory at `app/actions/home/show.rb`:
 module Bookshelf
   module Actions
     module Home
-      class Show < Bookshelf::Action
+      class Index < Bookshelf::Action
         def handle(request, response)
         end
       end
@@ -170,7 +170,7 @@ For now, let's adjust our home action to return our desired "Welcome to Bookshel
 module Bookshelf
   module Actions
     module Home
-      class Show < Bookshelf::Action
+      class Index < Bookshelf::Action
         def handle(request, response)
           response.body = "Welcome to Bookshelf"
         end
@@ -223,7 +223,7 @@ If you run this test, you'll see that it fails because our app currently returns
 Let's fix that by generating an action for a books index:
 
 ```shell
-$ bundle exec hanami generate action books.index --skip-view
+$ bundle exec hanami generate action books.index --skip-view --skip-tests
 ```
 
 In addition to generating an action at `app/actions/books/index.rb`, the generator has also added a route in `config/routes.rb`:
@@ -602,6 +602,8 @@ A helpful response revealing why parameter validation failed can also be rendere
 halt 422, {errors: request.params.errors}.to_json unless request.params.valid?
 ```
 
+We can also add a test to verify this:
+
 ```ruby
 # spec/requests/books/index/pagination_spec.rb
 
@@ -709,7 +711,7 @@ Finished in 0.05427 seconds (files took 0.88631 seconds to load)
 We can use Hanami's action generator to create both a route and an action. Run:
 
 ```shell
-$ bundle exec hanami generate action books.show --skip-view
+$ bundle exec hanami generate action books.show --skip-view --skip-tests
 ```
 
 If you inspect `config/routes.rb` you will see the generator has automatically added a new `get "/books/:id", to: "books.show"` route:
@@ -940,7 +942,7 @@ Executing this spec, we get the message `Method Not Allowed`, because there's no
 Hanami's action generator can add these for us:
 
 ```shell
-$ bundle exec hanami generate action books.create --skip-view
+$ bundle exec hanami generate action books.create --skip-view --skip-tests
 ```
 
 The app's routes now include the expected route - invoking the `books.create` action for `POST` requests to `/books`:

--- a/content/v2.2/introduction/getting-started.md
+++ b/content/v2.2/introduction/getting-started.md
@@ -99,7 +99,8 @@ $ tree --gitignore .
 │   ├── app.rb
 │   ├── assets.js
 │   ├── db
-│   │   └── migrate
+│   │   ├── migrate
+│   │   └── seeds.rb
 │   ├── puma.rb
 │   ├── routes.rb
 │   └── settings.rb
@@ -115,11 +116,15 @@ $ tree --gitignore .
     │   └── root_spec.rb
     ├── spec_helper.rb
     └── support
+        ├── db
+        │   └── cleaning.rb
+        ├── db.rb
         ├── features.rb
+        ├── operations.rb
         ├── requests.rb
         └── rspec.rb
 
-23 directories, 32 files
+26 directories, 36 files
 ```
 
 Here's how these files and directories are used:


### PR DESCRIPTION
Call the initially created action `home.index` instead of `home.show`, since this matches better with people's expectations, from feedback.

Use `--skip-route` and `--skip-tests` options when generating actions to ensure we don't leave any errant routes or create soon-to-be-failing tests.

Other minor tweaks and fixes.