### PR TITLE
Update hanamiversion to 2.2, and update copyright

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,6 +1,6 @@
 baseURL = "https://guides.hanamirb.org/"
 title = "Hanami Guides"
-copyright = "All rights reserved - 2022"
+copyright = "All rights reserved - 2024"
 languageCode = "en-us"
 theme = "hanami"
 googleAnalytics = "UA-47369640-3"
@@ -21,7 +21,7 @@ filename = "sitemap.xml"
 priority = 0.5
 
 [params]
-hanamiversion = "2.1"
+hanamiversion = "2.2"
 description = "Code guides for Hanami Ruby web framework"
 facebook = "hanamirb"
 twitter = "hanamirb"


### PR DESCRIPTION
I don't think `copyright` is used anywhere but I'm not 100% sure so to be safe I updated the year instead of removing it.