### PR TITLE
Link to 2.2 instead of 1.3

### DIFF
--- a/content/v1.3/views/overview.md
+++ b/content/v1.3/views/overview.md
@@ -1,8 +1,6 @@
 ---
 title: Overview
 order: 10
-aliases:
-  - "/views/overview"
 ---
 
 A view is an object that's responsible for rendering a template.

--- a/content/v1.3/views/testing.md
+++ b/content/v1.3/views/testing.md
@@ -1,8 +1,6 @@
 ---
 title: Testing
 order: 80
-aliases:
-  - "/views/testing"
 ---
 
 One of the advantages of views as objects is that we can unit test them.

--- a/content/v2.2/views/overview.md
+++ b/content/v2.2/views/overview.md
@@ -1,6 +1,8 @@
 ---
 title: Overview
 order: 10
+aliases:
+  - "/views/overview"
 ---
 
 Hanami provides a complete view system for rendering HTML, JSON and other formats.

--- a/content/v2.2/views/testing.md
+++ b/content/v2.2/views/testing.md
@@ -1,6 +1,8 @@
 ---
 title: Testing
 order: 101
+aliases:
+  - "/views/testing"
 ---
 
 Views in Hanami are designed to encourage easier testing of your views, with each aspect of views designed to support direct unit testing. This means you can test your views at whatever level of granularity makes sense for you.


### PR DESCRIPTION
I had a few links go to 1.3 instead of 2.2

The other pages in this folder are fine because they don't overlap with 2.x guides at all