### PR TITLE
[docs]: Add a note about how to generate migrations

### DIFF
--- a/content/v2.2/cli-commands/generate.md
+++ b/content/v2.2/cli-commands/generate.md
@@ -11,6 +11,7 @@ Hanami 2.1 provides a few generators:
 $ bundle exec hanami generate --help
 Commands:
   hanami generate action NAME
+  hanami generate migration NAME
   hanami generate part NAME
   hanami generate slice NAME
   hanami generate view NAME
@@ -28,6 +29,15 @@ Use the `--help` option to access all accepted options:
 
 ```shell
 $ bundle exec hanami generate action --help
+```
+
+
+### hanami generate migration
+
+Generates a [migration](v2.2/database/migrations/):
+
+```shell
+$ bundle exec hanami generate create_posts
 ```
 
 ### hanami generate part

--- a/content/v2.2/cli-commands/generate.md
+++ b/content/v2.2/cli-commands/generate.md
@@ -37,8 +37,15 @@ $ bundle exec hanami generate action --help
 Generates a [migration](v2.2/database/migrations/):
 
 ```shell
-$ bundle exec hanami generate create_posts
+$ bundle exec hanami generate migration create_posts
 ```
+
+Use the `--help` option to access all accepted options:
+
+```shell
+$ bundle exec hanami generate migration --help
+```
+
 
 ### hanami generate part
 

--- a/content/v2.2/database/migrations.md
+++ b/content/v2.2/database/migrations.md
@@ -16,6 +16,16 @@ config/db/migrate
 └── 20240717170318_add_published_at_to_posts.rb
 ```
 
+## Generating migrations
+
+Migrations can be generated via the Hanami CLI like so:
+
+```
+$ hanami generate migration create_posts
+```
+
+Which will create a timestamped migration with that looks roughly like this: `config/db/migrate/20240717170227_create_posts.rb`
+
 ## Direction
 
 Migration files are bi-directional, they define schema changes *forward* and *backward*, or `up` and `down` in Sequel’s syntax. This is important, in case your migration changes cause a problem you will want to roll them back as quickly as possible, and requiring a fresh migration to do this may take too much time.


### PR DESCRIPTION
I was looking through the migrations section and wasn't quite sure how to generate a migration. I eventually found it by running `hanami generate --help` and also noticed that the migration generation isn't documented in the Generators section either.