### PR TITLE
Link to forum instead of chat; drop snippets and social links

### DIFF
--- a/content/v1.3/introduction/getting-started.md
+++ b/content/v1.3/introduction/getting-started.md
@@ -23,7 +23,7 @@ aliases:
   In this guide we will set up our first Hanami project and build a simple bookshelf web application.
   We'll touch on all the major components of Hanami framework, all guided by tests.
   <br><br>
-  <strong>If you feel alone, or frustrated, don't give up, jump in our <a href="http://chat.hanamirb.org">chat</a> and ask for help.</strong>
+  <strong>If you feel alone, or frustrated, don't give up, jump in our <a href="http://discourse.hanamirb.org">forum</a> and ask for help.</strong>
   There will be someone more than happy to talk with you.
   <br><br>
   Enjoy,<br>

--- a/content/v1.3/upgrade-notes/v060.md
+++ b/content/v1.3/upgrade-notes/v060.md
@@ -59,4 +59,4 @@ aliases:
     end
     ```
 
-**If you have any problem, don't hesitate to look for help in [chat](http://chat.hanamirb.org).**
+**If you have any problem, don't hesitate to look for help in our [forum](http://discourse.hanamirb.org).**

--- a/content/v1.3/upgrade-notes/v070.md
+++ b/content/v1.3/upgrade-notes/v070.md
@@ -17,4 +17,4 @@ aliases:
 
   * Rename the environment variable on your server from `LOTUS_ENV` to `HANAMI_ENV`
 
-**If you have any problem, don't hesitate to look for help in [chat](http://chat.hanamirb.org).**
+**If you have any problem, don't hesitate to look for help in our [forum](http://discourse.hanamirb.org).**

--- a/content/v1.3/upgrade-notes/v080.md
+++ b/content/v1.3/upgrade-notes/v080.md
@@ -39,4 +39,4 @@ aliases:
 
 * [Optional] RSpec users can disable Rake 11 warnings by adding `config.warnings = false ` to the `RSpec.configure |config|` block in <code>spec/spec\_helper.rb</code>.
 
-**If you have any problem, don't hesitate to look for help in [chat](http://chat.hanamirb.org).**
+**If you have any problem, don't hesitate to look for help in our [forum](http://discourse.hanamirb.org).**

--- a/content/v1.3/upgrade-notes/v090.md
+++ b/content/v1.3/upgrade-notes/v090.md
@@ -92,4 +92,4 @@ end
 Hanami::Utils.require!("lib/bookshelf")
 ```
 
-**If you have any problem, don't hesitate to look for help in [chat](http://chat.hanamirb.org).**
+**If you have any problem, don't hesitate to look for help in our [forum](http://discourse.hanamirb.org).**

--- a/content/v1.3/upgrade-notes/v100.md
+++ b/content/v1.3/upgrade-notes/v100.md
@@ -82,4 +82,4 @@ module Bookshelf
 end
 ```
 
-**If you have any problem, don't hesitate to look for help in [chat](http://chat.hanamirb.org).**
+**If you have any problem, don't hesitate to look for help in our [forum](http://discourse.hanamirb.org).**

--- a/content/v1.3/upgrade-notes/v110.md
+++ b/content/v1.3/upgrade-notes/v110.md
@@ -11,4 +11,4 @@ aliases:
 
 * Run `bundle update hanami hanami-model`
 
-**If you have any problem, don't hesitate to look for help in [chat](http://chat.hanamirb.org).**
+**If you have any problem, don't hesitate to look for help in our [forum](http://discourse.hanamirb.org).**

--- a/content/v1.3/upgrade-notes/v120.md
+++ b/content/v1.3/upgrade-notes/v120.md
@@ -11,4 +11,4 @@ aliases:
 
 * Run `bundle update hanami hanami-model`
 
-**If you have any problem, don't hesitate to look for help in [chat](http://chat.hanamirb.org).**
+**If you have any problem, don't hesitate to look for help in our [forum](http://discourse.hanamirb.org).**

--- a/content/v1.3/upgrade-notes/v130.md
+++ b/content/v1.3/upgrade-notes/v130.md
@@ -41,4 +41,4 @@ end
 
 * Run `bundle update hanami hanami-model`
 
-**If you have any problem, don't hesitate to look for help in [chat](http://chat.hanamirb.org).**
+**If you have any problem, don't hesitate to look for help in our [forum](http://discourse.hanamirb.org).**

--- a/themes/hanami/layouts/_default/single.html
+++ b/themes/hanami/layouts/_default/single.html
@@ -88,28 +88,8 @@
             </a>
           </li>
           <li class="nav-item">
-            <a class="nav-link nav-link-icon" href="https://twitter.com/{{ .Site.Params.twitter }}" target="_blank" title="Follow Hanami on Twitter">
-              <i class="fa fa-twitter"></i>
-            </a>
-          </li>
-          <li class="nav-item">
-            <a class="nav-link nav-link-icon" href="https://www.facebook.com/{{ .Site.Params.twitter }}" target="_blank" title="Like Hanami on Facebook">
-              <i class="fa fa-facebook-square"></i>
-            </a>
-          </li>
-          <li class="nav-item">
-            <a class="nav-link nav-link-icon" href="https://www.instagram.com/{{ .Site.Params.twitter }}" target="_blank" title="Follow Hanami on Instagram">
-              <i class="fa fa-instagram"></i>
-            </a>
-          </li>
-          <li class="nav-item">
-            <a class="nav-link nav-link-icon" href="http://chat.hanamirb.org/" target="_blank" title="Hanami chat">
+            <a class="nav-link nav-link-icon" href="http://discourse.hanamirb.org/" target="_blank" title="Hanami forum">
               <i class="ni ni-chat-round"></i>
-            </a>
-          </li>
-          <li class="nav-item">
-            <a class="nav-link nav-link-icon" href="https://github.com/hanami/guides/releases" target="_blank" title="Download Hanami Guides for offline usage">
-              <i class="fa fa-cloud-download"></i>
             </a>
           </li>
           <!-- <li class="nav-item"> -->

--- a/themes/hanami/layouts/index.html
+++ b/themes/hanami/layouts/index.html
@@ -231,7 +231,7 @@
             <div class="row align-items-center">
               <div class="col-lg-8">
                 <h3 class="text-white">Want to learn more?</h3>
-                <p class="lead text-white mt-3">Maybe you want to have a look at our <strong><a href="https://snippets.hanamirb.org" target="_blank"><span class="text-primary">snippets</span></a></strong> or to ask questions in our <strong><a href="http://discourse.hanamirb.org" target="_blank"><span class="text-primary">forum</span></a></strong>.</p>
+                <p class="lead text-white mt-3">Feel free to ask questions in our <strong><a href="http://discourse.hanamirb.org" target="_blank"><span class="text-primary">forum</span></a></strong>.</p>
               </div>
               <div class="col-lg-3 ml-lg-auto">
                 <a href="http://discourse.hanamirb.org" class="btn btn-lg btn-block btn-white" target="_blank">
@@ -262,9 +262,6 @@
               </li>
               <li class="nav-item">
                 <a href="http://hanamirb.org/blog/" class="nav-link" target="_blank">Blog</a>
-              </li>
-              <li class="nav-item">
-                <a href="https://snippets.hanamirb.org" class="nav-link" target="_blank">Snippets</a>
               </li>
               <li class="nav-item">
                 <a href="https://github.com/hanami/guides" class="nav-link" target="_blank">Contribute</a>

--- a/themes/hanami/layouts/index.html
+++ b/themes/hanami/layouts/index.html
@@ -85,33 +85,9 @@
                 </a>
               </li>
               <li class="nav-item">
-                <a class="nav-link nav-link-icon" href="https://twitter.com/{{ .Site.Params.twitter }}" target="_blank" title="Follow Hanami on Twitter">
-                  <i class="fa fa-twitter"></i>
-                  <span class="nav-link-inner--text d-lg-none">Twitter</span>
-                </a>
-              </li>
-              <li class="nav-item">
-                <a class="nav-link nav-link-icon" href="https://www.facebook.com/{{ .Site.Params.twitter }}" target="_blank" title="Like Hanami on Facebook">
-                  <i class="fa fa-facebook-square"></i>
-                  <span class="nav-link-inner--text d-lg-none">Facebook</span>
-                </a>
-              </li>
-              <li class="nav-item">
-                <a class="nav-link nav-link-icon" href="https://www.instagram.com/{{ .Site.Params.twitter }}" target="_blank" title="Follow Hanami on Instagram">
-                  <i class="fa fa-instagram"></i>
-                  <span class="nav-link-inner--text d-lg-none">Instagram</span>
-                </a>
-              </li>
-              <li class="nav-item">
-                <a class="nav-link nav-link-icon" href="http://chat.hanamirb.org/" target="_blank" title="Hanami chat">
+                <a class="nav-link nav-link-icon" href="http://discourse.hanamirb.org/" target="_blank" title="Hanami forum">
                   <i class="ni ni-chat-round"></i>
-                  <span class="nav-link-inner--text d-lg-none">Chat</span>
-                </a>
-              </li>
-              <li class="nav-item">
-                <a class="nav-link nav-link-icon" href="https://github.com/hanami/guides/releases" target="_blank" title="Download Hanami Guides for offline usage">
-                  <i class="fa fa-cloud-download"></i>
-                  <span class="nav-link-inner--text d-lg-none">Downloads</span>
+                  <span class="nav-link-inner--text d-lg-none">Forum</span>
                 </a>
               </li>
               <!-- <li class="nav-item"> -->
@@ -255,12 +231,12 @@
             <div class="row align-items-center">
               <div class="col-lg-8">
                 <h3 class="text-white">Want to learn more?</h3>
-                <p class="lead text-white mt-3">Maybe you want to have a look at our <strong><a href="https://snippets.hanamirb.org" target="_blank"><span class="text-primary">snippets</span></a></strong> or to ask questions in our <strong><a href="http://chat.hanamirb.org" target="_blank"><span class="text-primary">chat</span></a></strong>.</p>
+                <p class="lead text-white mt-3">Maybe you want to have a look at our <strong><a href="https://snippets.hanamirb.org" target="_blank"><span class="text-primary">snippets</span></a></strong> or to ask questions in our <strong><a href="http://discourse.hanamirb.org" target="_blank"><span class="text-primary">forum</span></a></strong>.</p>
               </div>
               <div class="col-lg-3 ml-lg-auto">
-                <a href="http://chat.hanamirb.org" class="btn btn-lg btn-block btn-white" target="_blank">
+                <a href="http://discourse.hanamirb.org" class="btn btn-lg btn-block btn-white" target="_blank">
                   <span class="btn-inner--icon text-primary"><i class="ni ni-chat-round mr-2"></i></span>
-                  <span class="nav-link-inner--text text-primary">Join our chat</span>
+                  <span class="nav-link-inner--text text-primary">Join our forum</span>
                 </a>
               </div>
             </div>
@@ -270,26 +246,6 @@
     </section>
     <footer class="footer has-cards">
       <div class="container">
-        <div class="row row-grid align-items-center my-md">
-          <div class="col-lg-6">
-            <h3 class="text-primary font-weight-light mb-2">Thank you for supporting us!</h3>
-            <h4 class="mb-0 font-weight-light">Let's get in touch on any of these platforms.</h4>
-          </div>
-          <div class="col-lg-6 text-lg-center btn-wrapper">
-            <a target="_blank" href="https://github.com/{{ .Site.Params.Github }}" class="btn btn-neutral btn-icon-only btn-github btn-round btn-lg" data-toggle="tooltip" data-original-title="Star on Github">
-              <i class="fa fa-github"></i>
-            </a>
-            <a target="_blank" href="https://twitter.com/{{ .Site.Params.Twitter }}" class="btn btn-neutral btn-icon-only btn-twitter btn-round btn-lg" data-toggle="tooltip" data-original-title="Follow us">
-              <i class="fa fa-twitter"></i>
-            </a>
-            <a target="_blank" href="https://www.facebook.com/{{ .Site.Params.Facebook }}" class="btn btn-neutral btn-icon-only btn-facebook btn-round btn-lg" data-toggle="tooltip" data-original-title="Like us">
-              <i class="fa fa-facebook-square"></i>
-            </a>
-            <a target="_blank" href="https://instagram.com/{{ .Site.Params.Instagram }}" class="btn btn-neutral btn-icon-only btn-instagram btn-lg btn-round" data-toggle="tooltip" data-original-title="Follow us">
-              <i class="fa fa-instagram"></i>
-            </a>
-          </div>
-        </div>
         <hr>
         <div class="row align-items-center justify-content-md-between">
           <div class="col-md-6">

--- a/themes/hanami/layouts/index.html
+++ b/themes/hanami/layouts/index.html
@@ -250,9 +250,7 @@
         <div class="row align-items-center justify-content-md-between">
           <div class="col-md-6">
             <div class="copyright">
-            Hanami is a web framework for Ruby —
-            &copy; {{ now.Format "2006"}}
-            <a href="https://lucaguidi.com" target="_blank"><span class="text-primary">Luca Guidi</span></a>
+            Hanami is a web framework for Ruby
             </div>
           </div>
           <div class="col-md-6">

--- a/themes/hanami/layouts/partials/footer.html
+++ b/themes/hanami/layouts/partials/footer.html
@@ -8,9 +8,9 @@
             <p class="lead text-white mt-3">Maybe you want to have a look at our <strong><a href="https://snippets.hanamirb.org" target="_blank"><span class="text-primary">snippets</span></a></strong> or to ask questions in our <strong><a href="http://chat.hanamirb.org" target="_blank"><span class="text-primary">chat</span></a></strong>.</p>
           </div>
           <div class="col-lg-3 ml-lg-auto">
-            <a href="http://chat.hanamirb.org" class="btn btn-lg btn-block btn-white" target="_blank">
+            <a href="http://discourse.hanamirb.org" class="btn btn-lg btn-block btn-white" target="_blank">
               <span class="btn-inner--icon text-primary"><i class="ni ni-chat-round mr-2"></i></span>
-              <span class="nav-link-inner--text text-primary">Join our chat</span>
+              <span class="nav-link-inner--text text-primary">Join our forum</span>
             </a>
           </div>
         </div>
@@ -20,33 +20,13 @@
 </section>
 <footer class="footer has-cards">
   <div class="container">
-    <div class="row row-grid align-items-center my-md">
-      <div class="col-lg-6">
-        <h3 class="text-primary font-weight-light mb-2">Thank you for supporting us!</h3>
-        <h4 class="mb-0 font-weight-light">Let's get in touch on any of these platforms.</h4>
-      </div>
-      <div class="col-lg-6 text-lg-center btn-wrapper">
-        <a target="_blank" href="https://github.com/{{ .Site.Params.Github }}" class="btn btn-neutral btn-icon-only btn-github btn-round btn-lg" data-toggle="tooltip" data-original-title="Star on Github">
-          <i class="fa fa-github"></i>
-        </a>
-        <a target="_blank" href="https://twitter.com/{{ .Site.Params.Twitter }}" class="btn btn-neutral btn-icon-only btn-twitter btn-round btn-lg" data-toggle="tooltip" data-original-title="Follow us">
-          <i class="fa fa-twitter"></i>
-        </a>
-        <a target="_blank" href="https://www.facebook.com/{{ .Site.Params.Facebook }}" class="btn btn-neutral btn-icon-only btn-facebook btn-round btn-lg" data-toggle="tooltip" data-original-title="Like us">
-          <i class="fa fa-facebook-square"></i>
-        </a>
-        <a target="_blank" href="https://instagram.com/{{ .Site.Params.Instagram }}" class="btn btn-neutral btn-icon-only btn-instagram btn-lg btn-round" data-toggle="tooltip" data-original-title="Follow us">
-          <i class="fa fa-instagram"></i>
-        </a>
-      </div>
-    </div>
     <hr>
     <div class="row align-items-center justify-content-md-between">
       <div class="col-md-6">
         <div class="copyright">
           Hanami is a web framework for Ruby —
           &copy; {{ now.Format "2006"}}
-          <a href="https://lucaguidi.com" target="_blank"><span class="text-primary">Luca Guidi</span></a>
+          <a href="https://hanamirb.com" target="_blank"><span class="text-primary">Hanami team</span></a>
         </div>
       </div>
       <div class="col-md-6">

--- a/themes/hanami/layouts/partials/footer.html
+++ b/themes/hanami/layouts/partials/footer.html
@@ -5,7 +5,7 @@
         <div class="row align-items-center">
           <div class="col-lg-8">
             <h3 class="text-white">Still can't find an answer?</h3>
-            <p class="lead text-white mt-3">Maybe you want to have a look at our <strong><a href="https://snippets.hanamirb.org" target="_blank"><span class="text-primary">snippets</span></a></strong> or to ask questions in our <strong><a href="http://chat.hanamirb.org" target="_blank"><span class="text-primary">chat</span></a></strong>.</p>
+            <p class="lead text-white mt-3">Feel free to ask questions in our <strong><a href="http://discourse.hanamirb.org" target="_blank"><span class="text-primary">forum</span></a></strong>.</p>
           </div>
           <div class="col-lg-3 ml-lg-auto">
             <a href="http://discourse.hanamirb.org" class="btn btn-lg btn-block btn-white" target="_blank">
@@ -36,9 +36,6 @@
           </li>
           <li class="nav-item">
             <a href="http://hanamirb.org/blog/" class="nav-link" target="_blank">Blog</a>
-          </li>
-          <li class="nav-item">
-            <a href="https://snippets.hanamirb.org" class="nav-link" target="_blank">Snippets</a>
           </li>
           <li class="nav-item">
             <a href="https://github.com/hanami/guides" class="nav-link" target="_blank">Contribute</a>


### PR DESCRIPTION
We no longer use Gitter chat as a community contact point. Everything runs through [the forum](https://discourse.hanamirb.org/) instead. Drop all links to chat.