### PR TITLE
fix file name in introduction web app tutorial

### DIFF
--- a/content/v2.2/introduction/building-a-web-app.md
+++ b/content/v2.2/introduction/building-a-web-app.md
@@ -278,7 +278,7 @@ end
 Let's update our view to provide the books to our template:
 
 ```ruby
-# app/views/books/index.rb
+# app/templates/books/index.rb
 
 module Bookshelf
   module Views


### PR DESCRIPTION
There is a small error in the introduction guide.

The _books.show_ template path is wrong; it doesn't reflect the overall tutorial and makes subsequent steps fail (as the ERB templates are in templates, not views).