### PR TITLE
Fix a file path of `books.rb`

### DIFF
--- a/content/v2.2/introduction/building-a-web-app.md
+++ b/content/v2.2/introduction/building-a-web-app.md
@@ -364,7 +364,7 @@ $ bundle exec hanami generate relation books
 This creates the following file at `app/relations/books.rb`:
 
 ```ruby
-# lib/bookshelf/persistence/relations/books.rb
+# app/relations/books.rb
 
 module Bookshelf
   module Relations


### PR DESCRIPTION
This file is generated under `app/relations` in v2.2.