### PR TITLE
Add missing receiver when using `params`

### DIFF
--- a/content/v2.2/actions/http-caching.md
+++ b/content/v2.2/actions/http-caching.md
@@ -105,7 +105,7 @@ module Bookshelf
         include Deps["repos.user_repo"]
 
         def handle(request, response)
-          user = user_repo.find(params[:id])
+          user = user_repo.find(request.params[:id])
 
           response.fresh last_modified: user.updated_at
 
@@ -146,7 +146,7 @@ module Bookshelf
         include Deps["user_repo"]
 
         def handle(request, response)
-          user = user_repo.find(params[:id])
+          user = user_repo.find(request.params[:id])
 
           response.fresh etag: "#{user.id}-#{user.updated_at}"
 

--- a/content/v2.2/operations/overview.md
+++ b/content/v2.2/operations/overview.md
@@ -129,7 +129,7 @@ module Bookshelf
       include Deps["books.create"]
 
       def handle(request, response)
-        case create.call(params[:book])
+        case create.call(request.params[:book])
         in Success(book)
           response.redirect_to routes.path(:book, book.id)
         in Failure[:invalid, validation]


### PR DESCRIPTION
I think we can't use `params` without a receiver now.