### PR TITLE
Update building-an-api.md

### DIFF
--- a/content/v2.2/introduction/building-an-api.md
+++ b/content/v2.2/introduction/building-an-api.md
@@ -136,7 +136,7 @@ $ bundle exec hanami generate action home.index --skip-view --skip-route --skip-
 We can find this action in our `app` directory at `app/actions/home/index.rb`:
 
 ```ruby
-# app/actions/home/show.rb
+# app/actions/home/index.rb
 
 module Bookshelf
   module Actions


### PR DESCRIPTION
Fixed tiny error with guides.

When the index action is generated, the guides hint it's generated into the `show` file. This change corrects that