### PR TITLE
Add guide for building a static site

### DIFF
--- a/content/v2.2/introduction/building-a-static-site.md
+++ b/content/v2.2/introduction/building-a-static-site.md
@@ -1,0 +1,50 @@
+---
+title: "Building a static site"
+order: 30
+---
+
+Once we've [created our web app](/v2.2/introduction/building-a-web-app/), it's very easy to convert it fully or partially into a static site – with a little help of the [Parklife gem](https://rubygems.org/gems/parklife) which renders any Rack app into a build of static pages.
+
+## Install Parklife
+
+Add Parklife to the Gemfile and install it.
+
+```
+bundle add parklife
+bundle exec parklife init
+```
+
+## Configure Parklife
+
+The generated Parkfile does not work for Hanami, here's a more suitable blueprint which:
+
+* Boots the Hanami app.
+* Crawls the root page and all pages linked from there recursively.
+* Gets the explicitly declared page /errors/not-found which is not linked from anywhere.
+* Raises an error if it encounters a dead local link.
+
+```
+require "hanami/boot"
+
+Parklife.application.configure do |config|
+  config.app = Hanami.app
+  config.on_404 = :error
+end
+
+Parklife.application.routes do
+  root crawl: true
+
+  get '/errors/not-found'
+end
+```
+
+Please refer to the [Parklife config documentation](https://parklife.dev/config) for more.
+
+## Build
+
+To build the static pages into the `/build` directory:
+
+```
+bundle exec hanami assets compile
+bin/static-build
+```

--- a/content/v2.2/introduction/building-an-api.md
+++ b/content/v2.2/introduction/building-an-api.md
@@ -1,6 +1,6 @@
 ---
 title: "Building an API"
-order: 30
+order: 40
 ---
 
 Now that we've [created our app](/v2.2/introduction/getting-started/), let's turn it into an API.


### PR DESCRIPTION
So far, the guides introduce Hanami as a framework for (dynamic) web apps and APIs. However, Hanami ❤️ Parklife make a great team to build static sites as well.

The Parklife install docs don't work for Hanami and figuring out the necessary tweaks in the generated `Parkfile` is not so trivial if you don't know where to go for a peek (e.g. the Hanami site). So why not add another intro guide to showcase that Hanami can go static, too?

Well, here it is. :smile: