### PR TITLE
A suggested add to views/parts and a suggested fix to views/scopes.

### DIFF
--- a/content/v2.2/views/parts.md
+++ b/content/v2.2/views/parts.md
@@ -202,7 +202,7 @@ decorate :author, as: :person
 
 ## Memoizing methods
 
-A part object lives for the entirety of a single view rendering, so you can memoize expensive operations to ensure they only run once:
+A part object lives for the entirety of a single view rendering, so you can memoize expensive operations to ensure they only run once. `decorate` has a secondary function of memoizing:
 
 ```ruby
 class Book < Bookshelf::Views::Part

--- a/content/v2.2/views/scopes.md
+++ b/content/v2.2/views/scopes.md
@@ -57,7 +57,7 @@ scope(:media_player, item: audio_file)
 
 When you build a scope, the associated class will be looked up based on the scope's name.
 
-For example, given the exposure named `:media_player`, the `Views::Scopes::MediaPlayer` class will be looked up within your app or slice.
+For example, given the scope named `:media_player`, the `Views::Scopes::MediaPlayer` class will be looked up within your app or slice.
 
 If you have no scope class matching an the scope's name, then a generic `Hanami::View::Scope` will be used.
 


### PR DESCRIPTION
I was confused by the Memoization section of Views/Parts because it just seemed to repeat the example from Decorating above. But, it appears, correct me if I'm wrong, that `decorate` memoizes as well. I added some text to make that clear.

InViews/Scopes, "exposure" seemed wrong. I think it should be "scope".