### PR TITLE
Update the documentation on Struct to not utilize presentation

### DIFF
--- a/content/v2.2/database/overview.md
+++ b/content/v2.2/database/overview.md
@@ -119,7 +119,7 @@ For more on Repositories, see [ROM: Repositories](https://rom-rb.org/learn/repos
 
 The final output of a Repository is a Struct.
 
-A Hanami struct is immutable, and contains no business logic. They are extensible for adding presentation logic:
+A Hanami struct is immutable, and contains no business logic. They are extensible for adding read only data enhancements (For more complex logic consider utilizing an Operation):
 
 ```ruby
 module Main


### PR DESCRIPTION
Presentation is a loaded term, which implies data that will be visible to the user.  I was confused by this statement when reading the documentation. 

I hope the hint about an Operation is also helpful to another new person.