### PR TITLE
Exclude v2.3 from dropdown

### DIFF
--- a/static/robots.txt
+++ b/static/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /v2.3/

--- a/themes/hanami/layouts/_default/single.html
+++ b/themes/hanami/layouts/_default/single.html
@@ -67,8 +67,9 @@
               {{ range .Site.Sections }}
                 {{ $versionPathPrefix := replace .RelPermalink "/" "" }}
                 {{ $title := $versionPathPrefix }}
-
+                {{ if ne $versionPathPrefix "v2.3" }}
                 <option value="/{{ $versionPathPrefix }}{{ .Site.Params.startingpage }}" {{ if eq .Section $currentSection}}selected{{end}}>{{ $title }}</option>
+                {{ end }}
               {{ end }}
             </select>
           </li>


### PR DESCRIPTION
Clean up for #302.

It's fine if the pages are around, IMO, but we don't want people to discover them. I also added a robots.txt to remove the already-indexed pages from search engines, which I'll be responsible for removing once we launch 2.3