### PR TITLE
Fix a route description in getting started guide

### DIFF
--- a/content/v2.3/introduction/building-a-web-app.md
+++ b/content/v2.3/introduction/building-a-web-app.md
@@ -708,7 +708,7 @@ resources :books, only: [:index, :show, :new, :create, :edit, :update]
 
 This adds routes for updating books:
 
-- `GET /books/update/1` → `books.update` (to show the form)
+- `GET /books/update/1` → `books.edit` (to show the form)
 - `POST /books/1` → `books.update` (to handle the form submission)
 
 Now let's generate both actions:


### PR DESCRIPTION
I am quite new to Hanami and reading through the introduction guide, and I found `books.edit` is showing the form and handling the form submission. It seems like `books.edit` shows the edit form in a sample web app.